### PR TITLE
Plot improvements

### DIFF
--- a/react-app/src/components/FrequencyPlotComponent.tsx
+++ b/react-app/src/components/FrequencyPlotComponent.tsx
@@ -14,7 +14,7 @@ export default function FrequencyPlotComponent(prop: {
     populationColors: string[],
     }): ReactElement {
     
-    function generateTraces(data: IGeneFrequencyData[], colors: string[]): Plotly.Data[] {
+    function generateTraces(data: IGeneFrequencyData[], colors: string[], plotPosition: number): Plotly.Data[] {
         let regions: string[] = [];
         let frequencies: Number[] = [];
         let counts: Number[] = [];
@@ -26,14 +26,21 @@ export default function FrequencyPlotComponent(prop: {
         }
     
         let traces: Plotly.Data[] = [];
+
+        let showLegend = plotPosition === 1;
+        let legendGroupName = "";
     
         for (let i = 0; i < regions.length; i++) {
+            legendGroupName = plotPosition === 1 ? regions[i] : "AMR";
             traces.push(
                 {
                 x: [regions[i]] as Datum[],
                 y: [frequencies[i]] as Datum[],
+                xaxis: 'x'+plotPosition,
+                showlegend: showLegend,
                 type: 'bar',
-                name: regions[i],
+                legendgroup: "group" + i%5,
+                name: plotPosition === 1 ? regions[i] : "AMR",
                 text: 'n = ' + counts[i].toString(),
                 marker:{
                     color: [colors[i%colors.length] as any]
@@ -45,12 +52,17 @@ export default function FrequencyPlotComponent(prop: {
         return traces;
     }
 
-    let superpopulationTraces: Plotly.Data[] = generateTraces(prop.superpopulationAPIData, prop.superpopulationColors);
+    let superpopulationTraces: Plotly.Data[] = generateTraces(prop.superpopulationAPIData, prop.superpopulationColors, 1);
 
-    let populationTraces: Plotly.Data[] = generateTraces(prop.populationAPIData, prop.populationColors);
+    let populationTraces: Plotly.Data[] = generateTraces(prop.populationAPIData, prop.populationColors, 2);
 
-    const superpopulationsLayout: Partial<Layout> = {
+    let data = [...superpopulationTraces, ...populationTraces];
+
+    const layout: Partial<Layout> = {
+        height: 500,
+        width: 1250,
         xaxis: {title: '', showticklabels: false},
+        xaxis2: {title: '<b>Population<b>'},
         paper_bgcolor: '#f8fafc',
         plot_bgcolor: '#f8fafc',
         yaxis: {side: 'left', title: 'Allele Frequency', titlefont: {size: 15}},
@@ -60,32 +72,22 @@ export default function FrequencyPlotComponent(prop: {
             orientation: 'h',
         },
         margin: {l: 100, r: 40, b: 40, t: 30, pad: 1},
+        grid: {rows: 1, columns: 2},
     };
-//     plot1 <- plot_ly(df_pops, 
-//         type = 'bar', 
-//         text = ~value,
-//         x = ~population, 
-//         y = ~frequency, 
-//         color = ~population, 
-//         colors = c("#3D8F86")) %>%
-// add_text(text=~n, textfont = t, textposition="top center",
-//    showlegend = F) %>%
-// layout(yaxis = list(side = 'left', title = 'Allele Frequency', size = 10, titlefont = list(size = 15)),
-//  xaxis = list(title = '<b>Population<b>'), showlegend = F,
-//  margin = list(l=100, r=40, b=40, t=30, pad=1))
-    const populationsLayout: Partial<Layout> = {
-        xaxis: {title: '<b>Population<b>'},
-        paper_bgcolor: '#f8fafc',
-        plot_bgcolor: '#f8fafc',
-        yaxis: {side: 'left', title: 'Allele Frequency', titlefont: {size: 15}},
-        showlegend: false,
-        margin: {l: 100, r: 40, b: 75, t: 30, pad: 1},
-    };
+
+    // const populationsLayout: Partial<Layout> = {
+    //     xaxis: {title: '<b>Population<b>'},
+    //     paper_bgcolor: '#f8fafc',
+    //     plot_bgcolor: '#f8fafc',
+    //     yaxis: {side: 'left', title: 'Allele Frequency', titlefont: {size: 15}},
+    //     showlegend: false,
+    //     margin: {l: 100, r: 40, b: 75, t: 30, pad: 1},
+    // };
 
     return (
         <div className="flex flex-row -mx-24 items-center justify-center">
-            <Plot data={superpopulationTraces} layout={superpopulationsLayout} />
-            <Plot data={populationTraces} layout={populationsLayout} />
+            <Plot data={data} layout={layout} />
+            {/* <Plot data={populationTraces} layout={populationsLayout} /> */}
         </div>
     );
 }

--- a/react-app/src/interfaces/types.ts
+++ b/react-app/src/interfaces/types.ts
@@ -59,6 +59,19 @@ export interface IGeneFrequencyData {
     population: string;
 }
 
+export interface IPopulationRegion {
+    superpopulation: string;
+    population: string;
+}
+
+export interface ISuperpopulationColors {
+    AFR: string;
+    AMR: string;
+    EAS: string;
+    EUR: string;
+    SAS: string;
+}
+
 export type ChangeLogComponentProps = {
     title: string;
     doi: string;

--- a/react-app/src/pages/HomePage.tsx
+++ b/react-app/src/pages/HomePage.tsx
@@ -102,8 +102,8 @@ export default function HomePage(): ReactElement {
         .catch(response => console.log(response.error));
     }
 
-    async function downloadGeneFasta(fastaFileName: string) {
-        let fastaEndpoint = backendAPI + "fasta/" + fastaFileName;
+    async function downloadGeneFasta(geneSegment: string) {
+        let fastaEndpoint = backendAPI + "fasta/" + geneSegment;
         await axios.get(fastaEndpoint, {
             headers: {
               "Content-Type": 'attachment'
@@ -111,7 +111,7 @@ export default function HomePage(): ReactElement {
            })
             .then(response => {
                 let responseData: Blob = response.data;
-                fileDownload(responseData, fastaFileName);
+                fileDownload(responseData, geneSegment + '.fasta');
             })
             .catch(response => console.log(response.error));
     }
@@ -198,13 +198,13 @@ export default function HomePage(): ReactElement {
         <p className='text-primary-content text-xl font-semibold'>Downloadable Fasta Files</p>
         <div className="grid grid-flow-col gap-4">
               <div className="text-info-content text-base flex justify-center items-center w-44 h-10 px-8 py-2 bg-info font-medium opacity-80 rounded-lg shadow-inner backdrop-blur-2xl transform transition duration-300 ease-in-out hover:scale-105 hover:shadow-lg hover:bg-fuchsia-800">
-              <button onClick={() => downloadGeneFasta('IGHV.fasta')}>IGHV</button>
+              <button onClick={() => downloadGeneFasta('IGHV')}>IGHV</button>
               </div>
               <div className="text-info-content text-base flex justify-center items-center w-44 h-10 px-8 py-2 bg-info font-medium opacity-80 rounded-lg shadow-inner backdrop-blur-2xl transform transition duration-300 ease-in-out hover:scale-105 hover:shadow-lg hover:bg-fuchsia-800">
-              <button onClick={() => downloadGeneFasta('IGHJ.fasta')}>IGHJ</button>
+              <button onClick={() => downloadGeneFasta('IGHJ')}>IGHJ</button>
               </div>
               <div className="text-info-content text-base flex justify-center items-center w-44 h-10 px-8 py-2 bg-info font-medium opacity-80 rounded-lg shadow-inner backdrop-blur-2xl transform transition duration-300 ease-in-out hover:scale-105 hover:shadow-lg hover:bg-fuchsia-800">
-              <button onClick={() => downloadGeneFasta('IGHD.fasta')}>IGHD</button>
+              <button onClick={() => downloadGeneFasta('IGHD')}>IGHD</button>
               </div>
         </div>
       </div>


### PR DESCRIPTION
Made populations a subplot of superpopulations, with populations and superpopulations ordered according to Hedestam's requests as well as using their requested colors. The population plot is now colored and ordered after superpopulations, and clicking superpopulations in the legend allows for deselecting superpopulations and populations at the same time.

Code is unfortunately pretty brute force, should be rewritten to be more dynamic and thus easier to change and adapt later. But it does its job for now.

Added a minor change in fetching fastas because I slightly changed the fasta endpoint, snuck in that change here rather than making a whole new branch for it.