### PR TITLE
H_2 import disappeared when fixing conflict

### DIFF
--- a/react-app/src/pages/HomePage.tsx
+++ b/react-app/src/pages/HomePage.tsx
@@ -2,6 +2,7 @@ import { ReactElement } from 'react';
 import { BODY_CLASSES, 
         // BUTTON_TYPE_ONE, 
         // H_1
+        H_2
     } from '../constants';
 import { TrackPageViewIfEnabled } from '../util/cookiesHandling';
 import { Link } from 'react-router-dom';


### PR DESCRIPTION
Accidentally removed H_2 import while resolving conflicts. Added it back in and tested running locally with npm run dev as well as in my local argoCD, seems to be working correctly.