### PR TITLE
Dynamic plot option selection frontend

### DIFF
--- a/react-app/src/pages/PlotPage.tsx
+++ b/react-app/src/pages/PlotPage.tsx
@@ -193,21 +193,7 @@ export default function PlotPage(): ReactElement {
           })
           .catch((response) => console.log(response.error));
       }
-    }, [currentPicks]);
-
-    // fetch next selection options after gene is selected
-    useEffect(() => {
-      let currentSelection = currentPicks.geneDropdown + currentPicks.geneSegmentDropdown;
-      setAlleleDropDownItemsArray([])
-      axios
-        .get(geneSelectionEndpoint + currentSelection)
-        .then((response) => {
-          let responseData = response.data;
-          responseData.push("...");
-          setAlleleDropDownItemsArray(responseData);
-        })
-        .catch((response) => console.log(response.error));
-    }, [currentPicks.geneSegmentDropdown]);
+    }, [currentPicks.geneDropdown, currentPicks.subtypeDropdown]);
 
   // Render the component
   return (


### PR DESCRIPTION
Fetching plot selection options from backend and dynamically showing them in list now functional.

Backend by receiving a request with current selection and sending back the next possible part, for example:

Receive IGHV: send back a list of ['1-2', '1-4', ...].

Receive IGHV1-2: send back list of ['*02', '*04', ...].

I thought that for now, hardcoding 'IGH' and 'IGHV', 'IGHD' and 'IGHJ' in the frontend works fine and is easier. Since we won't have that many options in the end anyway, it might be fine to just keep this first part in the frontend code.

The two selections after that were turned into useState functions. When a selection is made in the second part (['IGHV,' 'IGHD', 'IGHJ']) a useEffect is triggered to send the current selection to the backend. The next part of the selection then gets updated by setting the useState array for that part. Selecting something in that array triggers finding the next selection in a similar way.

This will break the frontend if not using the new version of the backend, so we'll need to make a release with the new backend.