### PR TITLE
Fixed issue with allele names

### DIFF
--- a/next-app/src/components/PlotPageComponent.tsx
+++ b/next-app/src/components/PlotPageComponent.tsx
@@ -133,6 +133,9 @@ export default function PlotPage(): ReactElement {
 
   async function getGeneFreqData(allele: string) {
     const alleleFrequenciesEndpoint: string = backendAPI + "data/frequencies/";
+    // allele names sometimes contain slashes, which breaks the functionality of the API as it interprets it as a path
+    // replace with '&slash&' and replace again with '/' in the api
+    allele = allele.replace('/', '&slash&');
     const superpopulationsEndpoint: string =
       alleleFrequenciesEndpoint + "superpopulations/" + allele;
 


### PR DESCRIPTION
Fixed problem where allele names containing slashes were interpreted as URI paths. If they contain a '/' character, it now gets replaced with '&slash&' in the request from the frontend, and then turned back to '/' in the backend.