### PR TITLE
Adjust frontend for new MSA endpoints in backend

### DIFF
--- a/next-app/src/components/MSAPlotPageComponent.tsx
+++ b/next-app/src/components/MSAPlotPageComponent.tsx
@@ -34,7 +34,7 @@ export default function MSAPlotPageComponent(): ReactElement {
     'geneSelectionEndpoint': backendAPI + "data/aminoacidplotoptions/"
   }
 
-  const [selectedAllele, setSelectedAllele] = useState<string>("");
+  const [selectedGene, setSelectedGene] = useState<string>("");
 
   const [sequenceData, setSequenceData] = useState<ISequenceData[]>([{'allele': 'Allele', 'sequence': 'SEQUENCE'}]);
   const [aminoAcidSequence, setAminoAcidSequence] = useState<ISequenceData[]>([{'allele': 'Allele', 'sequence': 'SEQUENCE'}]);
@@ -50,8 +50,8 @@ export default function MSAPlotPageComponent(): ReactElement {
         const tmpAminoAcidSequence = [];
         const tmpSequenceData = [];
         for (item of responseData) {
-          tmpAminoAcidSequence.push({'allele': item.aa_allele, 'sequence': item.aa_sequence});
-          tmpSequenceData.push(item.allele_data[0])
+          tmpSequenceData.push({'allele': item.allele, 'sequence': item.sequence_nt})
+          tmpAminoAcidSequence.push({'allele': item.allele, 'sequence': item.sequence_aa});
         }
         setAminoAcidSequence(tmpAminoAcidSequence);
         setSequenceData(tmpSequenceData);
@@ -61,15 +61,21 @@ export default function MSAPlotPageComponent(): ReactElement {
 
   // Fetch data when allele dropdown changes
   useEffect(() => {
-    if (selectedAllele) {
+    if (selectedGene) {
       if (!hasCookie('password')) {
         const allele_data_sample: string = "IGHV1-18*01_AA"
         const strToKey = allele_data_sample as keyof typeof sampleMSAData[0];
-        setSequenceData(sampleMSAData[0][strToKey].allele_data)
-        setAminoAcidSequence([{'allele': "IGHV1-18*01", 'sequence': sampleMSAData[0][strToKey].aa_sequence}])
+        const tmpAminoAcidSequenceLite = [];
+        const tmpSequenceDataLite = [];
+        for (let item of sampleMSAData) {
+          tmpSequenceDataLite.push({'allele': item.allele, 'sequence': item.sequence_nt})
+          tmpAminoAcidSequenceLite.push({'allele': item.allele, 'sequence': item.sequence_aa});
+        }
+        setSequenceData(tmpSequenceDataLite)
+        setAminoAcidSequence(tmpAminoAcidSequenceLite)
       }
       else {
-        AASequenceData(selectedAllele);
+        AASequenceData(selectedGene);
       }
     }
     else {
@@ -77,7 +83,7 @@ export default function MSAPlotPageComponent(): ReactElement {
       setAminoAcidSequence([{'allele': 'Allele', 'sequence': 'SEQUENCE'}]);
     }
   }, [
-    selectedAllele
+    selectedGene
   ]);
 
   // check on page load if password cookie has been set yet, and if it has add to axios headers for all requests to backend
@@ -94,7 +100,7 @@ export default function MSAPlotPageComponent(): ReactElement {
   // function to be passed as prop to AlleleSelectionComponent, so that it can modify
   // state in parent component
   function handleSetSelection(allele: string) {
-    setSelectedAllele(allele);
+    setSelectedGene(allele);
   }
 
   // Render the component

--- a/next-app/src/content/localPlotData.ts
+++ b/next-app/src/content/localPlotData.ts
@@ -802,24 +802,44 @@ export const sampleAlleleDataAminoAcidPlot = {
   }
 
 export const sampleMSAData = [
-  {
-    "IGHV1-18*01_AA": {
-      "aa_sequence": "QVQLVQSGAEVKKPGASVKVSCKASGYTFTSYGISWVRQAPGQGLEWMGWISAYNGNTNYAQKLQGRVTMTTDTSTSTAYMELRSLRSDDTAVYYCAR",
-      "allele_data": 
-        [
-          {"allele": "IGHV1-18*01",
-          "sequence": "CAGGTTCAGCTGGTGCAGTCTGGAGCTGAGGTGAAGAAGCCTGGGGCCTCAGTGAAGGTCTCCTGCAAGGCTTCTGGTTACACCTTTACCAGCTATGGTATCAGCTGGGTGCGACAGGCCCCTGGACAAGGGCTTGAGTGGATGGGATGGATCAGCGCTTACAATGGTAACACAAACTATGCACAGAAGCTCCAGGGCAGAGTCACCATGACCACAGACACATCCACGAGCACAGCCTACATGGAGCTGAGGAGCCTGAGATCTGACGACACGGCCGTGTATTACTGTGCGAGAGA"
-          },
-          {"allele": "IGHV1-18*01_S0898",
-          "sequence": "CAGGTGCAGCTGGTGCAGTCTGGAGCTGAGGTGAAGAAGCCTGGGGCCTCAGTGAAGGTCTCCTGCAAGGCTTCTGGTTACACCTTTACCAGCTATGGTATCAGCTGGGTGCGACAGGCCCCTGGACAAGGGCTTGAGTGGATGGGATGGATCAGCGCTTACAATGGTAACACAAACTATGCACAGAAGCTCCAGGGCAGAGTCACCATGACCACAGACACATCCACGAGCACAGCCTACATGGAGCTGAGGAGCCTGAGATCTGACGACACGGCCGTGTATTACTGTGCGAGAGA"
-          },
-          {"allele": "IGHV1-18*01_S1946",
-          "sequence": "CAGGTCCAGCTGGTGCAGTCTGGAGCTGAGGTGAAGAAGCCTGGGGCCTCAGTGAAGGTCTCCTGCAAGGCTTCTGGTTACACCTTTACCAGCTATGGTATCAGCTGGGTGCGACAGGCCCCTGGACAAGGGCTTGAGTGGATGGGATGGATCAGCGCTTACAATGGTAACACAAACTATGCACAGAAGCTCCAGGGCAGAGTCACCATGACCACAGACACATCCACGAGCACAGCCTACATGGAGCTGAGGAGCCTGAGATCTGACGACACGGCCGTGTATTACTGTGCGAGAGA"
-          },
-          {"allele": "IGHV1-18*04",
-          "sequence": "CAGGTTCAGCTGGTGCAGTCTGGAGCTGAGGTGAAGAAGCCTGGGGCCTCAGTGAAGGTCTCCTGCAAGGCTTCTGGTTACACCTTTACCAGCTACGGTATCAGCTGGGTGCGACAGGCCCCTGGACAAGGGCTTGAGTGGATGGGATGGATCAGCGCTTACAATGGTAACACAAACTATGCACAGAAGCTCCAGGGCAGAGTCACCATGACCACAGACACATCCACGAGCACAGCCTACATGGAGCTGAGGAGCCTGAGATCTGACGACACGGCCGTGTATTACTGTGCGAGAGA"
-          }
-        ]
-    }
-  }
+	{
+		"allele": "IGHV1-18*01",
+		"sequence_aa": "QVQLVQSGAEVKKPGASVKVSCKASGYTFTSYGISWVRQAPGQGLEWMGWISAYNGNTNYAQKLQGRVTMTTDTSTSTAYMELRSLRSDDTAVYYCAR",
+		"sequence_nt": "caggttcagctggtgcagtctggagctgaggtgaagaagcctggggcctcagtgaaggtctcctgcaaggcttctggttacacctttaccagctatggtatcagctgggtgcgacaggcccctggacaagggcttgagtggatgggatggatcagcgcttacaatggtaacacaaactatgcacagaagctccagggcagagtcaccatgaccacagacacatccacgagcacagcctacatggagctgaggagcctgagatctgacgacacggccgtgtattactgtgcgagaga"
+	},
+	{
+		"allele": "IGHV1-18*01_S0898",
+		"sequence_aa": "QVQLVQSGAEVKKPGASVKVSCKASGYTFTSYGISWVRQAPGQGLEWMGWISAYNGNTNYAQKLQGRVTMTTDTSTSTAYMELRSLRSDDTAVYYCAR",
+		"sequence_nt": "caggtgcagctggtgcagtctggagctgaggtgaagaagcctggggcctcagtgaaggtctcctgcaaggcttctggttacacctttaccagctatggtatcagctgggtgcgacaggcccctggacaagggcttgagtggatgggatggatcagcgcttacaatggtaacacaaactatgcacagaagctccagggcagagtcaccatgaccacagacacatccacgagcacagcctacatggagctgaggagcctgagatctgacgacacggccgtgtattactgtgcgagaga"
+	},
+	{
+		"allele": "IGHV1-18*01_S1946",
+		"sequence_aa": "QVQLVQSGAEVKKPGASVKVSCKASGYTFTSYGISWVRQAPGQGLEWMGWISAYNGNTNYAQKLQGRVTMTTDTSTSTAYMELRSLRSDDTAVYYCAR",
+		"sequence_nt": "caggtccagctggtgcagtctggagctgaggtgaagaagcctggggcctcagtgaaggtctcctgcaaggcttctggttacacctttaccagctatggtatcagctgggtgcgacaggcccctggacaagggcttgagtggatgggatggatcagcgcttacaatggtaacacaaactatgcacagaagctccagggcagagtcaccatgaccacagacacatccacgagcacagcctacatggagctgaggagcctgagatctgacgacacggccgtgtattactgtgcgagaga"
+	},
+	{
+		"allele": "IGHV1-18*01_S2590",
+		"sequence_aa": "QVQLVQSGAEVKKPGASVKVSCKASGYTFTSYGISWVRQAPGQGLEWMGWISAYNGNTNYAQKLQDRVTMTTDTSTSTAYMELRSLRSDDTAVYYCAR",
+		"sequence_nt": "caggttcagctggtgcagtctggagctgaggtgaagaagcctggggcctcagtgaaggtctcctgcaaggcttctggttacacctttaccagctatggtatcagctgggtgcgacaggcccctggacaagggcttgagtggatgggatggatcagcgcttacaatggtaacacaaactatgcacagaagctccaggacagagtcaccatgaccacagacacatccacgagcacagcctacatggagctgaggagcctgagatctgacgacacggccgtgtattactgtgcgagaga"
+	},
+	{
+		"allele": "IGHV1-18*01_S4206",
+		"sequence_aa": "QVQLVQSGAEVKKPGASVKVSCKASGYTFTSYGISWVRQAPGQGLEWMGWISAYNGDTNYAQKLQGRVTMTTDTSTSTAYMELRSLRSDDTAVYYCAR",
+		"sequence_nt": "caggttcagctggtgcagtctggagctgaggtgaagaagcctggggcctcagtgaaggtctcctgcaaggcttctggttacacctttaccagctatggtatcagctgggtgcgacaggcccctggacaagggcttgagtggatgggatggatcagcgcttacaatggtgacacaaactatgcacagaagctccagggcagagtcaccatgaccacagacacatccacgagcacagcctacatggagctgaggagcctgagatctgacgacacggccgtgtattactgtgcgagaga"
+	},
+	{
+		"allele": "IGHV1-18*01_S8907",
+		"sequence_aa": "QVQLVQSGAEVKKPGASVKVSCKASGYTFTSYGISWVRQAPGQGLEWMGWISAYNGNTNYAQKLQGRVTMTTDTSTSTAYMELRRLRSDDTAVYYCAR",
+		"sequence_nt": "caggttcagctggtgcagtctggagctgaggtgaagaagcctggggcctcagtgaaggtctcctgcaaggcttctggttacacctttaccagctatggtatcagctgggtgcgacaggcccctggacaagggcttgagtggatgggatggatcagcgcttacaatggtaacacaaactatgcacagaagctccagggcagagtcaccatgaccacagacacatccacgagcacagcctacatggagctgaggaggctgagatctgacgacacggccgtgtattactgtgcgagaga"
+	},
+	{
+		"allele": "IGHV1-18*03",
+		"sequence_aa": "QVQLVQSGAEVKKPGASVKVSCKASGYTFTSYGISWVRQAPGQGLEWMGWISAYNGNTNYAQKLQGRVTMTTDTSTSTAYMELRSLRSDDMAVYYCAR",
+		"sequence_nt": "caggttcagctggtgcagtctggagctgaggtgaagaagcctggggcctcagtgaaggtctcctgcaaggcttctggttacacctttaccagctatggtatcagctgggtgcgacaggcccctggacaagggcttgagtggatgggatggatcagcgcttacaatggtaacacaaactatgcacagaagctccagggcagagtcaccatgaccacagacacatccacgagcacagcctacatggagctgaggagcctgagatctgacgacatggccgtgtattactgtgcgagaga"
+	},
+	{
+		"allele": "IGHV1-18*04",
+		"sequence_aa": "QVQLVQSGAEVKKPGASVKVSCKASGYTFTSYGISWVRQAPGQGLEWMGWISAYNGNTNYAQKLQGRVTMTTDTSTSTAYMELRSLRSDDTAVYYCAR",
+		"sequence_nt": "caggttcagctggtgcagtctggagctgaggtgaagaagcctggggcctcagtgaaggtctcctgcaaggcttctggttacacctttaccagctacggtatcagctgggtgcgacaggcccctggacaagggcttgagtggatgggatggatcagcgcttacaatggtaacacaaactatgcacagaagctccagggcagagtcaccatgaccacagacacatccacgagcacagcctacatggagctgaggagcctgagatctgacgacacggccgtgtattactgtgcgagaga"
+	}
 ]

--- a/next-app/src/interfaces/types.ts
+++ b/next-app/src/interfaces/types.ts
@@ -151,7 +151,7 @@ export type ISequenceSearchData = {
 }
 
 export type IMSAData = {
-  aa_allele: string;
-  aa_sequence: string;
-  allele_data: ISequenceData[];
+  allele: string;
+  sequence_nt: string;
+  sequence_aa: string;
 }


### PR DESCRIPTION
Fixed API calls so that new MSA data format is correctly handled, as the data structure was changed a bit when rebuilding to use MAFFT in the backend.