### PR TITLE
Disable IGHJ from flanking fasta download

### DIFF
--- a/next-app/src/app/download/page.tsx
+++ b/next-app/src/app/download/page.tsx
@@ -237,7 +237,7 @@ export default function DownloadPage(): ReactElement {
           geneObjectArray={[
             { name: "IGHV", isAvailable: true },
             { name: "IGHD", isAvailable: true },
-            { name: "IGHJ", isAvailable: true },
+            { name: "IGHJ", isAvailable: (fastaTypeSelected === 'coding') },
             { name: "IGH constant", isAvailable: false },
           ]}
           setPropsSelectionArray={setIghSelectionArray}


### PR DESCRIPTION
Disabled IGHJ from downloads if genomic with flanking regions is selected, as per Hedestam group's request (it has no data).