### PR TITLE
Fixes for plot options, minor fixes

### DIFF
--- a/next-app/src/app/download/page.tsx
+++ b/next-app/src/app/download/page.tsx
@@ -131,38 +131,44 @@ export default function DownloadPage(): ReactElement {
       })
     }
   }, [])
+  
+  function setIsDisclaimerPopupOpen(arg0: boolean): void {
+    if (arg0) {
+      console.log("Disclaimer popup button not implemented.");
+    }
+  }
 
   return (
     <div className={BODY_CLASSES}>
       <h1 className={H_1}>Download FASTA files</h1>
-
-      <button
-        className="bg-warning text-warning-content text-base lg:text-lg flex gap-2 justify-center items-center px-4 order-first lg:px-0 w-full h-12 font-bold rounded-3xl shadow-inner backdrop-blur-2xl transform transition duration-300 ease-in-out hover:opacity-90"
-        onClick={() => setIsPopupOpen(true)}
-      >
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          className="h-6 w-6 shrink-0 stroke-current"
-          fill="none"
-          viewBox="0 0 24 24"
+      
+      {!hasCookie("password") && (
+        <button
+          className="bg-warning text-warning-content text-base lg:text-lg flex gap-2 justify-center items-center px-4 order-first lg:px-0 w-full h-12 font-bold rounded-3xl shadow-inner backdrop-blur-2xl transform transition duration-300 ease-in-out hover:opacity-90"
+          onClick={() => setIsDisclaimerPopupOpen(true)}
         >
-          <path
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            strokeWidth="2"
-            d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
-          />
-        </svg>
-        Disclaimer
-      </button>
-      {!hasCookie('password') && isPopupOpen && (
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            className="h-6 w-6 shrink-0 stroke-current"
+            fill="none"
+            viewBox="0 0 24 24"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth="2"
+              d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
+            />
+          </svg>
+          Disclaimer
+        </button>
+      )}
+      {!hasCookie("password") && setIsDisclaimerPopupOpen && (
         <DisclaimerPopupComponent
-          onClose={() => setIsPopupOpen(false)}
+          onClose={() => setIsDisclaimerPopupOpen(false)}
           explanation="This page is fully developed and allows you to explore its
                       design and functionality. However, the underlying data has
-                      not been officially published yet, so downloading FASTA
-                      files is currently unavailable. Once the research group
-                      publishes the data, this feature will become accessible."
+                      not been officially published yet. Therefore, we can currently only showcase a sample of the data for demonstration purposes."
         />
       )}
 

--- a/next-app/src/components/AlleleSelectionComponent.tsx
+++ b/next-app/src/components/AlleleSelectionComponent.tsx
@@ -79,7 +79,10 @@ export default function AlelleSelectionComponent(prop: {
     } else {
       if (!currentPicks.subtypeDropdown) {
         setAlleleDropDownItemsArray(["..."]);
-        const currentSelection = currentPicks.geneDropdown;
+        let currentSelection = currentPicks.geneDropdown;
+        // allele names sometimes contain slashes, which breaks the functionality of the API as it interprets it as a path
+        // replace with '&slash&' and replace again with '/' in the api
+        currentSelection = currentSelection.replace('/', '&slash&');
         axios
           .get(geneSelectionEndpoint + currentSelection, axiosConfig)
           .then((response) => {
@@ -89,8 +92,12 @@ export default function AlelleSelectionComponent(prop: {
           })
           .catch((response) => console.log(response.error));
       } else {
-        const currentSelection =
-          currentPicks.geneDropdown + currentPicks.subtypeDropdown + "*";
+        let currentSelection =
+          currentPicks.geneDropdown + currentPicks.subtypeDropdown + "$";
+
+        // allele names sometimes contain slashes, which breaks the functionality of the API as it interprets it as a path
+        // replace with '&slash&' and replace again with '/' in the api
+        currentSelection = currentSelection.replace('/', '&slash&');
         setAlleleDropDownItemsArray([]);
         axios
           .get(geneSelectionEndpoint + currentSelection, axiosConfig)
@@ -123,6 +130,7 @@ export default function AlelleSelectionComponent(prop: {
         prop.handleSetSelection(
           currentPicks.geneDropdown +
             currentPicks.subtypeDropdown +
+            "$" +
             currentPicks.alleleDropdown
         );
       }
@@ -213,8 +221,8 @@ export default function AlelleSelectionComponent(prop: {
             currentPicks.subtypeDropdown &&
             currentPicks.alleleDropdown ? (
               <>
-                Plot for {currentPicks.geneDropdown}{" "}
-                {currentPicks.subtypeDropdown} {currentPicks.alleleDropdown}
+                Plot for {currentPicks.geneDropdown}
+                {currentPicks.subtypeDropdown} {"*"} {currentPicks.alleleDropdown}
               </>
             ) : (
               "Please select the gene type, gene and allele above"


### PR DESCRIPTION
Fixed interaction between plot options in frontend and backend; switched to separating with '$' rather than '*' which appears naturally in the source data's strings. Replace '/' with '&slash&' in all relevant places, as '/' will mess up the API call path.

Removed disclaimer from download page if the user has entered password.