### PR TITLE
Minor fixes for fetching data from backend

### DIFF
--- a/next-app/src/components/MSAPlotPageComponent.tsx
+++ b/next-app/src/components/MSAPlotPageComponent.tsx
@@ -40,6 +40,9 @@ export default function MSAPlotPageComponent(): ReactElement {
   const [aminoAcidSequence, setAminoAcidSequence] = useState<ISequenceData[]>([{'allele': 'Allele', 'sequence': 'SEQUENCE'}]);
 
   async function AlignedSequenceData(gene: string) {
+    // allele names sometimes contain slashes, which breaks the functionality of the API as it interprets it as a path
+    // replace with '&slash&' and replace again with '/' in the api
+    gene = gene.replace('/', '&slash&');
     const AlignedSequenceDataEndpoint: string = backendAPI + "data/sequences/alignedsequences/" + gene;
 
     await axios

--- a/next-app/src/components/PlotPageComponent.tsx
+++ b/next-app/src/components/PlotPageComponent.tsx
@@ -99,6 +99,9 @@ export default function PlotPage(): ReactElement {
   }
 
   async function getGeneIgSNPerData(allele: string) {
+    // allele names sometimes contain slashes, which breaks the functionality of the API as it interprets it as a path
+    // replace with '&slash&' and replace again with '/' in the api
+    allele = allele.replace('/', '&slash&');
     const alleleIgSNPerDataEndpoint: string =
       backendAPI + "data/igsnperdata/" + allele;
     await axios


### PR DESCRIPTION
Fixed bugs where '/' in gene data request strings were not converted to '&slash&' before requesting data, causing the request path to be broken.

For example, if we send backend/IGHV1-20*01 it works as intended, but backend/IGHV1-65*01/IGHV1-65D*01 (made up example) would cause the path to be wrongly interpreted as IGHV1-65D*01 being a subpath of IGHV1-65*01. Therefore we need to send the data as backend/IGHV1-65*01&slash&IGHV1-65D*01. This has already been done in several places but was missed in a couple of places causing bugs.