### PR TITLE
fix: only track visits from live website

### DIFF
--- a/next-app/src/components/MatomoInit.tsx
+++ b/next-app/src/components/MatomoInit.tsx
@@ -5,12 +5,14 @@ import { init } from "@socialgouv/matomo-next";
 
 export default function MatomoInit() {
   useEffect(() => {
-    init({
-        url: 'https://matomo.dc.scilifelab.se/', 
-        siteId: '12',
-        disableCookies: true,
-        excludeUrlsPatterns: [/^\/password/,],
-    })
+    if (window.location.origin === "https://kiarva.scilifelab.se") {
+      init({
+          url: 'https://matomo.dc.scilifelab.se/', 
+          siteId: '12',
+          disableCookies: true,
+          excludeUrlsPatterns: [/^\/password/,],
+      })
+    }
   }, [])
 
   return null


### PR DESCRIPTION
fix: only track visits if the origin is the live production page, i.e. not from dev or test instances. Check if the origin is https://kiarva.scilifelab.se before initializing Matomo.