### PR TITLE
518/fix: Use string encoding for backend requests (frontend part)

### DIFF
--- a/next-app/src/app/download/page.tsx
+++ b/next-app/src/app/download/page.tsx
@@ -38,10 +38,11 @@ export default function DownloadPage(): ReactElement {
 
   async function downloadGeneFasta(gene: string) {
     const fastaType =
-      fastaTypeSelected === "coding" ? "" : fastaTypeSelected + "/";
-    const fastaEndpoint = backendAPI + "fasta/" + fastaType + gene;
+      fastaTypeSelected === "coding" ? "" : "/" + fastaTypeSelected;
+    const fastaEndpoint = backendAPI + "fasta" + fastaType + "?file_name=" + gene;
+    const encodedURI = encodeURI(fastaEndpoint);
     await axios
-      .get(fastaEndpoint, axiosConfig)
+      .get(encodedURI, axiosConfig)
       .then((response) => {
         const responseData: Blob = response.data;
         fileDownload(
@@ -61,11 +62,12 @@ export default function DownloadPage(): ReactElement {
     const zip = new JSZip();
     let gene: string;
     const fastaType =
-      fastaTypeSelected === "coding" ? "" : fastaTypeSelected + "/";
+      fastaTypeSelected === "coding" ? "" : "/" + fastaTypeSelected;
     for (gene of genes) {
-      const fastaEndpoint = backendAPI + "fasta/" + fastaType + gene;
+      const fastaEndpoint = backendAPI + "fasta" + fastaType + "?file_name=" + gene;
+      const encodedURI = encodeURI(fastaEndpoint);
       await axios
-        .get(fastaEndpoint, axiosConfig)
+        .get(encodedURI, axiosConfig)
         .then((response) => {
           const responseData: Blob = response.data;
           zip.file(

--- a/next-app/src/app/sequencesearch/page.tsx
+++ b/next-app/src/app/sequencesearch/page.tsx
@@ -40,7 +40,7 @@ export default function SequenceSearchInputForm() {
       }
     })
 
-  const sequenceSearchEndpoint = backendAPI + "data/sequences/"
+  const sequenceSearchEndpoint = backendAPI + "data/sequences?sequence_str="
   const [sequenceData, setSequenceData] = useState<ISequenceSearchData[]>([]);
   const [searchTermLength, setSearchTermLength] = useState<number>(0);
 
@@ -60,8 +60,9 @@ export default function SequenceSearchInputForm() {
         </pre>
       ),
     })
+    const encodedURI = encodeURI(sequenceSearchEndpoint + data.sequence);
     await axios
-    .get(sequenceSearchEndpoint + data.sequence, axiosConfig)
+    .get(encodedURI, axiosConfig)
     .then((response) => {
       setSearchTermLength(data.sequence.length);
       setSequenceData(response.data);

--- a/next-app/src/components/AAPlotPageComponent.tsx
+++ b/next-app/src/components/AAPlotPageComponent.tsx
@@ -66,19 +66,19 @@ export default function AminoAcidPlotPage(): ReactElement {
   const alleleDropdownConfig: IAlleleDropDownConfig = {
     geneSegmentItemsArray: ["IGH"],
     geneDropDownItemsArray: ["IGHV"],
-    geneSelectionEndpoint: backendAPI + "data/plotoptions/",
+    geneSelectionEndpoint: backendAPI + "data/plotoptions?current_selection=",
   };
 
   const [selectedAllele, setSelectedAllele] = useState<string>("");
   const [topAlleleAA, setTopAlleleAA] = useState<string>("");
 
   async function getTopLevelAlleleAA(allele: string) {
-    allele = allele.replace("/", "&slash&");
     const topAlleleAAEndpoint: string =
-      backendAPI + "/data/aminoacidalleles/" + allele;
+      backendAPI + "/data/aminoacidalleles?aa_allele_name=" + allele;
 
+    const encodedURI = encodeURI(topAlleleAAEndpoint);
     await axios
-      .get(topAlleleAAEndpoint, axiosConfig)
+      .get(encodedURI, axiosConfig)
       .then((response) => {
         setTopAlleleAA(response.data.allele_aa);
       })
@@ -88,23 +88,23 @@ export default function AminoAcidPlotPage(): ReactElement {
   async function getGeneFreqData(allele: string) {
     const alleleFrequenciesEndpoint: string =
       backendAPI + "data/aminoacidfrequencies/";
-    // allele names sometimes contain slashes, which breaks the functionality of the API as it interprets it as a path
-    // replace with '&slash&' and replace again with '/' in the api
-    allele = allele.replace("/", "&slash&");
-    const superpopulationsEndpoint: string =
-      alleleFrequenciesEndpoint + "superpopulations/" + allele;
 
+    const superpopulationsEndpoint: string =
+      alleleFrequenciesEndpoint + "superpopulations?aa_allele_name=" + allele;
+
+    const superPopEncodedURI = encodeURI(superpopulationsEndpoint);
     await axios
-      .get(superpopulationsEndpoint, axiosConfig)
+      .get(superPopEncodedURI, axiosConfig)
       .then((response) => {
         setSuperpopFreqAPIData(response.data);
       })
       .catch((response) => console.log(response.error));
 
     const populationsEndpoint: string =
-      alleleFrequenciesEndpoint + "populations/" + allele;
+      alleleFrequenciesEndpoint + "populations?aa_allele_name=" + allele;
+    const popEncodedURI = encodeURI(populationsEndpoint);
     await axios
-      .get(populationsEndpoint, axiosConfig)
+      .get(popEncodedURI, axiosConfig)
       .then((response) => {
         setPopFreqAPIData(response.data);
       })
@@ -113,9 +113,10 @@ export default function AminoAcidPlotPage(): ReactElement {
 
   async function getAlleleListAA(allele: string) {
     const alleleListAADataEndpoint: string =
-      backendAPI + "data/aminoacidlist/" + allele;
+      backendAPI + "data/aminoacidlist?aa_allele_name=" + allele;
+    const encodedURI = encodeURI(alleleListAADataEndpoint);
     await axios
-      .get(alleleListAADataEndpoint, axiosConfig)
+      .get(encodedURI, axiosConfig)
       .then((response) => {
         const responseData: AlleleListAA = response.data;
         if (responseData.aa_allele_list) {
@@ -131,7 +132,7 @@ export default function AminoAcidPlotPage(): ReactElement {
         getTopLevelAlleleAA(selectedAllele);
       }
       else {
-        const selectedAlleleTmp = selectedAllele.replace('$', '');
+        const selectedAlleleTmp = selectedAllele.replace('*', '');
         const strToKey =
           selectedAlleleTmp as keyof typeof sampleAlleleDataAminoAcidPlot;
         setSuperpopFreqAPIData(

--- a/next-app/src/components/AlleleSelectionComponent.tsx
+++ b/next-app/src/components/AlleleSelectionComponent.tsx
@@ -80,9 +80,7 @@ export default function AlelleSelectionComponent(prop: {
       if (!currentPicks.subtypeDropdown) {
         setAlleleDropDownItemsArray(["..."]);
         let currentSelection = currentPicks.geneDropdown;
-        // allele names sometimes contain slashes, which breaks the functionality of the API as it interprets it as a path
-        // replace with '&slash&' and replace again with '/' in the api
-        currentSelection = currentSelection.replace('/', '&slash&');
+
         axios
           .get(geneSelectionEndpoint + currentSelection, axiosConfig)
           .then((response) => {
@@ -93,11 +91,8 @@ export default function AlelleSelectionComponent(prop: {
           .catch((response) => console.log(response.error));
       } else {
         let currentSelection =
-          currentPicks.geneDropdown + currentPicks.subtypeDropdown + "$";
+          currentPicks.geneDropdown + currentPicks.subtypeDropdown + "*";
 
-        // allele names sometimes contain slashes, which breaks the functionality of the API as it interprets it as a path
-        // replace with '&slash&' and replace again with '/' in the api
-        currentSelection = currentSelection.replace('/', '&slash&');
         setAlleleDropDownItemsArray([]);
         axios
           .get(geneSelectionEndpoint + currentSelection, axiosConfig)
@@ -130,7 +125,7 @@ export default function AlelleSelectionComponent(prop: {
         prop.handleSetSelection(
           currentPicks.geneDropdown +
             currentPicks.subtypeDropdown +
-            "$" +
+            "*" +
             currentPicks.alleleDropdown
         );
       }

--- a/next-app/src/components/AlleleSelectionComponent.tsx
+++ b/next-app/src/components/AlleleSelectionComponent.tsx
@@ -79,7 +79,7 @@ export default function AlelleSelectionComponent(prop: {
     } else {
       if (!currentPicks.subtypeDropdown) {
         setAlleleDropDownItemsArray(["..."]);
-        let currentSelection = currentPicks.geneDropdown;
+        const currentSelection = currentPicks.geneDropdown;
 
         axios
           .get(geneSelectionEndpoint + currentSelection, axiosConfig)
@@ -90,7 +90,7 @@ export default function AlelleSelectionComponent(prop: {
           })
           .catch((response) => console.log(response.error));
       } else {
-        let currentSelection =
+        const currentSelection =
           currentPicks.geneDropdown + currentPicks.subtypeDropdown + "*";
 
         setAlleleDropDownItemsArray([]);

--- a/next-app/src/components/MSAPlotPageComponent.tsx
+++ b/next-app/src/components/MSAPlotPageComponent.tsx
@@ -26,7 +26,7 @@ export default function MSAPlotPageComponent(): ReactElement {
   const alleleDropdownConfig: IAlleleDropDownConfig = {
     geneSegmentItemsArray: ["IGH"],
     geneDropDownItemsArray: ["IGHV"],
-    geneSelectionEndpoint: backendAPI + "data/plotoptions/",
+    geneSelectionEndpoint: backendAPI + "data/plotoptions?current_selection=",
   };
 
   const [selectedGene, setSelectedGene] = useState<string>("");
@@ -39,14 +39,13 @@ export default function MSAPlotPageComponent(): ReactElement {
   ]);
 
   async function AlignedSequenceData(gene: string) {
-    // allele names sometimes contain slashes, which breaks the functionality of the API as it interprets it as a path
-    // replace with '&slash&' and replace again with '/' in the api
-    gene = gene.replace("/", "&slash&");
-    const AlignedSequenceDataEndpoint: string =
-      backendAPI + "data/sequences/alignedsequences/" + gene;
 
+    const alignedSequenceDataEndpoint: string =
+      backendAPI + "data/sequences/alignedsequences?gene_name=" + gene;
+
+    const encodedURI = encodeURI(alignedSequenceDataEndpoint);
     await axios
-      .get(AlignedSequenceDataEndpoint, axiosConfig)
+      .get(encodedURI, axiosConfig)
       .then((response) => {
         const responseData: IMSAData[] = response.data;
         let item: IMSAData;

--- a/next-app/src/components/PlotPageComponent.tsx
+++ b/next-app/src/components/PlotPageComponent.tsx
@@ -64,30 +64,30 @@ export default function PlotPage(): ReactElement {
   const alleleDropdownConfig: IAlleleDropDownConfig = {
     'geneSegmentItemsArray': ["IGH"],
     'geneDropDownItemsArray': ["IGHV"],
-    'geneSelectionEndpoint': backendAPI + "data/plotoptions/"
+    'geneSelectionEndpoint': backendAPI + "data/plotoptions?current_selection="
   }
 
   const [selectedAllele, setSelectedAllele] = useState<string>("");
 
   async function getGeneFreqData(allele: string) {
     const alleleFrequenciesEndpoint: string = backendAPI + "data/frequencies/";
-    // allele names sometimes contain slashes, which breaks the functionality of the API as it interprets it as a path
-    // replace with '&slash&' and replace again with '/' in the api
-    allele = allele.replace('/', '&slash&');
-    const superpopulationsEndpoint: string =
-      alleleFrequenciesEndpoint + "superpopulations/" + allele;
 
+    const superpopulationsEndpoint: string =
+      alleleFrequenciesEndpoint + "superpopulations?allele_name=" + allele;
+
+    const superPopEncodedURI = encodeURI(superpopulationsEndpoint);
     await axios
-      .get(superpopulationsEndpoint, axiosConfig)
+      .get(superPopEncodedURI, axiosConfig)
       .then((response) => {
         setSuperpopFreqAPIData(response.data);
       })
       .catch((response) => console.log(response.error));
 
     const populationsEndpoint: string =
-      alleleFrequenciesEndpoint + "populations/" + allele;
+      alleleFrequenciesEndpoint + "populations?allele_name=" + allele;
+    const popEncodedURI = encodeURI(populationsEndpoint);
     await axios
-      .get(populationsEndpoint, axiosConfig)
+      .get(popEncodedURI, axiosConfig)
       .then((response) => {
         setPopFreqAPIData(response.data);
       })
@@ -95,13 +95,13 @@ export default function PlotPage(): ReactElement {
   }
 
   async function getGeneIgSNPerData(allele: string) {
-    // allele names sometimes contain slashes, which breaks the functionality of the API as it interprets it as a path
-    // replace with '&slash&' and replace again with '/' in the api
-    allele = allele.replace('/', '&slash&');
+
     const alleleIgSNPerDataEndpoint: string =
-      backendAPI + "data/igsnperdata/" + allele;
+      backendAPI + "data/igsnperdata?allele_name=" + allele;
+
+    const encodedURI = encodeURI(alleleIgSNPerDataEndpoint);
     await axios
-      .get(alleleIgSNPerDataEndpoint, axiosConfig)
+      .get(encodedURI, axiosConfig)
       .then((response) => {
         const responseData: IgSNPerData = response.data;
         if (responseData.igSNPer_score || responseData.igSNPer_score === 0) {

--- a/next-app/src/content/localPlotData.ts
+++ b/next-app/src/content/localPlotData.ts
@@ -148,7 +148,7 @@ export const populationSubsets = [
   ]
 
 export const sampleAlleleDataGenomicPlot = {
-    'IGHV1-2$02_S4953': 
+    'IGHV1-2*02_S4953': 
     {
       'superpopulation':
       [
@@ -321,7 +321,7 @@ export const sampleAlleleDataGenomicPlot = {
         "rs373342578(T:261,106452929)"
       ],
     },
-    'IGHV1-2$04':
+    'IGHV1-2*04':
     {
       'superpopulation':
       [
@@ -494,7 +494,7 @@ export const sampleAlleleDataGenomicPlot = {
         "rs112806369(A:98,106452766)"
       ],
     },
-    'IGHV1-2$06':
+    'IGHV1-2*06':
     {
       'superpopulation':
       [


### PR DESCRIPTION
https://scilifelab.atlassian.net/browse/TP-518

fix: Changed all endpoints to use URI queries and encoding rather than relying on unencoded URI strings. Removed hacky solutions to getting around the URI string limitations by replacing special characters.