### PR TITLE
484: Adding version in Footer

### DIFF
--- a/next-app/next.config.mjs
+++ b/next-app/next.config.mjs
@@ -10,10 +10,6 @@ const nextConfig = {
           },
         ]
     },
-    // env: {
-    //   NEXT_PUBLIC_FRONTEND_IMAGE: "ghcr.io/scilifelabdatacentre/kiarva-frontend:0.8.0",
-    //   NEXT_PUBLIC_BACKEND_IMAGE: "ghcr.io/scilifelabdatacentre/kiarva-backend:0.12.2",
-    // },
 };
 
 export default nextConfig;

--- a/next-app/next.config.mjs
+++ b/next-app/next.config.mjs
@@ -11,7 +11,8 @@ const nextConfig = {
         ]
     },
     // env: {
-    //     BACKEND_API_URL: 'http://localhost:5000/',
+    //   NEXT_PUBLIC_FRONTEND_IMAGE: "ghcr.io/scilifelabdatacentre/kiarva-frontend:0.8.0",
+    //   NEXT_PUBLIC_BACKEND_IMAGE: "ghcr.io/scilifelabdatacentre/kiarva-backend:0.12.2",
     // },
 };
 

--- a/next-app/src/app/meta/version/route.ts
+++ b/next-app/src/app/meta/version/route.ts
@@ -1,0 +1,8 @@
+import { NextResponse } from 'next/server'
+
+export function GET() {
+  return NextResponse.json({
+    frontendImage: process.env.NEXT_PUBLIC_FRONTEND_IMAGE || '',
+    backendImage: process.env.NEXT_PUBLIC_BACKEND_IMAGE || '',
+  })
+}

--- a/next-app/src/components/DisplayAppVersion.tsx
+++ b/next-app/src/components/DisplayAppVersion.tsx
@@ -1,0 +1,37 @@
+'use client'
+import { useEffect, useState } from 'react'
+
+export default function FooterVersion() {
+  const [frontendImage, setFrontendImage] = useState<string | null>(null)
+  const [backendImage, setBackendImage] = useState<string | null>(null)
+
+  useEffect(() => {
+    fetch('/meta/version')
+      .then((res) => res.json())
+      .then((data) => {
+        setFrontendImage(data.frontendImage)
+        setBackendImage(data.backendImage)
+      })
+  }, [])
+
+  return (
+    <div className="flex flex-col">
+      <nav>
+        <a href={frontendImage || '/'}>
+          <p className="text-info-content text-opacity-80 text-sm">
+            Frontend version:{' '}
+            {frontendImage?.split(':')[1] || 'Unable to find version'}
+          </p>
+        </a>
+      </nav>
+      <nav>
+        <a href={backendImage || '/'}>
+          <p className="text-info-content text-opacity-80 text-sm">
+            Backend version:{' '}
+            {backendImage?.split(':')[1] || 'Unable to find version'}
+          </p>
+        </a>
+      </nav>
+    </div>
+  )
+}

--- a/next-app/src/components/DisplayAppVersion.tsx
+++ b/next-app/src/components/DisplayAppVersion.tsx
@@ -17,7 +17,7 @@ export default function FooterVersion() {
   return (
     <div className="flex flex-col">
       <nav>
-        <a href={frontendImage || '/'}>
+        <a href={'https://'+frontendImage || '/'}>
           <p className="text-info-content text-opacity-80 text-sm">
             Frontend version:{' '}
             {frontendImage?.split(':')[1] || 'Unable to find version'}
@@ -25,7 +25,7 @@ export default function FooterVersion() {
         </a>
       </nav>
       <nav>
-        <a href={backendImage || '/'}>
+        <a href={'https://'+backendImage || '/'}>
           <p className="text-info-content text-opacity-80 text-sm">
             Backend version:{' '}
             {backendImage?.split(':')[1] || 'Unable to find version'}

--- a/next-app/src/components/DisplayAppVersion.tsx
+++ b/next-app/src/components/DisplayAppVersion.tsx
@@ -1,37 +1,58 @@
-'use client'
-import { useEffect, useState } from 'react'
+"use client";
+import { useEffect, useState } from "react";
+import { LINK_CLASSES } from "@/constants";
 
 export default function FooterVersion() {
-  const [frontendImage, setFrontendImage] = useState<string | null>(null)
-  const [backendImage, setBackendImage] = useState<string | null>(null)
+  const [frontendImage, setFrontendImage] = useState<string | null>(null);
+  const [backendImage, setBackendImage] = useState<string | null>(null);
 
   useEffect(() => {
-    fetch('/meta/version')
+    fetch("/meta/version")
       .then((res) => res.json())
       .then((data) => {
-        setFrontendImage(data.frontendImage)
-        setBackendImage(data.backendImage)
-      })
-  }, [])
+        setFrontendImage(data.frontendImage);
+        setBackendImage(data.backendImage);
+      });
+  }, []);
 
   return (
-    <div className="flex flex-col">
+    <div className="grid grid-cols-2 lg:grid-cols-4 gap-4 lg:gap-8">
       <nav>
-        <a href={'https://'+frontendImage || '/'}>
-          <p className="text-info-content text-opacity-80 text-sm">
-            Frontend version:{' '}
-            {frontendImage?.split(':')[1] || 'Unable to find version'}
+        <a href={"https://" + frontendImage || "/"}>
+          <p className={`text-info-content/70 text-sm ${LINK_CLASSES}`}>
+            Frontend version: {frontendImage?.split(":")[1] || "n/a"}
           </p>
         </a>
       </nav>
       <nav>
-        <a href={'https://'+backendImage || '/'}>
-          <p className="text-info-content text-opacity-80 text-sm">
-            Backend version:{' '}
-            {backendImage?.split(':')[1] || 'Unable to find version'}
+        <a href={"https://" + backendImage || "/"}>
+          <p className={`text-info-content/70 text-sm ${LINK_CLASSES}`}>
+            Backend version: {backendImage?.split(":")[1] || "n/a"}
+          </p>
+        </a>
+      </nav>
+      <nav>
+        <a
+          href="https://precision-medicine-portal.scilifelab.se/privacy"
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          <p className={`text-info-content/70 text-sm ${LINK_CLASSES}`}>
+            Privacy policy
+          </p>
+        </a>
+      </nav>
+      <nav>
+        <a
+          href="https://precision-medicine-portal.scilifelab.se/citation-and-license"
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          <p className={`text-info-content/70 text-sm ${LINK_CLASSES}`}>
+            Citation and license
           </p>
         </a>
       </nav>
     </div>
-  )
+  );
 }

--- a/next-app/src/components/FooterComponent.tsx
+++ b/next-app/src/components/FooterComponent.tsx
@@ -5,6 +5,7 @@ import { ILink } from "@/interfaces/types";
 import { LINK_CLASSES } from "@/constants";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
+import DisplayAppVersion from "@/components/DisplayAppVersion";
 
 const footerBackground = "images/hedestamFooterImage.png";
 
@@ -60,6 +61,7 @@ export default function FooterComponent(): ReactElement {
               ))}
           </nav>
         </div>
+        <DisplayAppVersion />
         <nav className="justify-self-end">
           <a
             href="https://precision-medicine-portal.scilifelab.se/privacy"

--- a/next-app/src/components/FooterComponent.tsx
+++ b/next-app/src/components/FooterComponent.tsx
@@ -60,21 +60,8 @@ export default function FooterComponent(): ReactElement {
                 </Link>
               ))}
           </nav>
+          <DisplayAppVersion />
         </div>
-        <DisplayAppVersion />
-        <nav className="justify-self-end">
-          <a
-            href="https://precision-medicine-portal.scilifelab.se/privacy"
-            rel="noopener noreferrer"
-            target="_blank"
-          >
-            <p
-              className={`text-info-content text-opacity-80 text-sm ${LINK_CLASSES}`}
-            >
-              Privacy Policy
-            </p>
-          </a>
-        </nav>
       </footer>
     </div>
   );

--- a/next-app/src/constants.ts
+++ b/next-app/src/constants.ts
@@ -18,9 +18,7 @@ let backendAPI_tmp = '';
 if (typeof window !== 'undefined') {
   backendAPI_tmp =
   window.location.origin === "http://localhost:3000"
-    ? process.env.BACKEND_API_URL
-      ? process.env.BACKEND_API_URL
-      : "https://kiarva.scilifelab-2-dev.sys.kth.se/api/"
+    ? "http://localhost:5000"
     : window.location.origin + "/api/";
 }
 export const backendAPI = backendAPI_tmp;


### PR DESCRIPTION
https://scilifelab.atlassian.net/browse/TP-484

feature: Set up functionality so that we can use environmental variables from kubernetes to display currently deployed version numbers in footer.

Note: Adding the versions screwed up the styling a bit, "Privacy" in lower right corner is now below the footer image and is invisible because it's white text on white background. Unsure how to fix it/how to style it so it looks good. @JanProgrammierung can you take a look at it?

Note 2: Should be tested in dev cluster before pushed to prod, since we're changin the kubernetes setup. Just to be safe.