### PR TITLE
550 - Fixes for endpoint requests

### DIFF
--- a/next-app/src/app/download/page.tsx
+++ b/next-app/src/app/download/page.tsx
@@ -34,12 +34,12 @@ export default function DownloadPage(): ReactElement {
   });
 
   async function downloadGeneFasta(gene: string) {
+    const encodedGene = encodeURIComponent(gene);
     const fastaType =
       fastaTypeSelected === "coding" ? "" : "/" + fastaTypeSelected;
-    const fastaEndpoint = backendAPI + "fasta" + fastaType + "?file_name=" + gene;
-    const encodedURI = encodeURI(fastaEndpoint);
+    const fastaEndpoint = backendAPI + "fasta" + fastaType + "?file_name=" + encodedGene;
     await axios
-      .get(encodedURI, axiosConfig)
+      .get(fastaEndpoint, axiosConfig)
       .then((response) => {
         const responseData: Blob = response.data;
         fileDownload(
@@ -61,10 +61,10 @@ export default function DownloadPage(): ReactElement {
     const fastaType =
       fastaTypeSelected === "coding" ? "" : "/" + fastaTypeSelected;
     for (gene of genes) {
-      const fastaEndpoint = backendAPI + "fasta" + fastaType + "?file_name=" + gene;
-      const encodedURI = encodeURI(fastaEndpoint);
+      const encodedGene = encodeURIComponent(gene);
+      const fastaEndpoint = backendAPI + "fasta" + fastaType + "?file_name=" + encodedGene;
       await axios
-        .get(encodedURI, axiosConfig)
+        .get(fastaEndpoint, axiosConfig)
         .then((response) => {
           const responseData: Blob = response.data;
           zip.file(

--- a/next-app/src/app/password/page.tsx
+++ b/next-app/src/app/password/page.tsx
@@ -16,7 +16,6 @@ export default function PasswordPage(): ReactElement {
     }
 
     async function handleSubmit(): Promise<void> {
-        console.log(backend_password_uri)
         const config = {
             headers: {
                 'X-api-key': inputField,

--- a/next-app/src/app/password/page.tsx
+++ b/next-app/src/app/password/page.tsx
@@ -16,6 +16,7 @@ export default function PasswordPage(): ReactElement {
     }
 
     async function handleSubmit(): Promise<void> {
+        console.log(backend_password_uri)
         const config = {
             headers: {
                 'X-api-key': inputField,

--- a/next-app/src/components/AAPlotPageComponent.tsx
+++ b/next-app/src/components/AAPlotPageComponent.tsx
@@ -73,12 +73,12 @@ export default function AminoAcidPlotPage(): ReactElement {
   const [topAlleleAA, setTopAlleleAA] = useState<string>("");
 
   async function getTopLevelAlleleAA(allele: string) {
+    const encodedAllele = encodeURIComponent(allele)
     const topAlleleAAEndpoint: string =
-      backendAPI + "/data/aminoacidalleles?aa_allele_name=" + allele;
+      backendAPI + "/data/aminoacidalleles?aa_allele_name=" + encodedAllele;
 
-    const encodedURI = encodeURI(topAlleleAAEndpoint);
     await axios
-      .get(encodedURI, axiosConfig)
+      .get(topAlleleAAEndpoint, axiosConfig)
       .then((response) => {
         setTopAlleleAA(response.data.allele_aa);
       })
@@ -86,25 +86,25 @@ export default function AminoAcidPlotPage(): ReactElement {
   }
 
   async function getGeneFreqData(allele: string) {
+    const encodedAllele = encodeURIComponent(allele)
     const alleleFrequenciesEndpoint: string =
       backendAPI + "data/aminoacidfrequencies/";
 
     const superpopulationsEndpoint: string =
-      alleleFrequenciesEndpoint + "superpopulations?aa_allele_name=" + allele;
+      alleleFrequenciesEndpoint + "superpopulations?aa_allele_name=" + encodedAllele;
 
-    const superPopEncodedURI = encodeURI(superpopulationsEndpoint);
     await axios
-      .get(superPopEncodedURI, axiosConfig)
+      .get(superpopulationsEndpoint, axiosConfig)
       .then((response) => {
         setSuperpopFreqAPIData(response.data);
       })
       .catch((response) => console.log(response.error));
 
     const populationsEndpoint: string =
-      alleleFrequenciesEndpoint + "populations?aa_allele_name=" + allele;
-    const popEncodedURI = encodeURI(populationsEndpoint);
+      alleleFrequenciesEndpoint + "populations?aa_allele_name=" + encodedAllele;
+
     await axios
-      .get(popEncodedURI, axiosConfig)
+      .get(populationsEndpoint, axiosConfig)
       .then((response) => {
         setPopFreqAPIData(response.data);
       })
@@ -112,11 +112,12 @@ export default function AminoAcidPlotPage(): ReactElement {
   }
 
   async function getAlleleListAA(allele: string) {
+    const encodedAllele = encodeURIComponent(allele)
     const alleleListAADataEndpoint: string =
-      backendAPI + "data/aminoacidlist?aa_allele_name=" + allele;
-    const encodedURI = encodeURI(alleleListAADataEndpoint);
+      backendAPI + "data/aminoacidlist?aa_allele_name=" + encodedAllele;
+
     await axios
-      .get(encodedURI, axiosConfig)
+      .get(alleleListAADataEndpoint, axiosConfig)
       .then((response) => {
         const responseData: AlleleListAA = response.data;
         if (responseData.aa_allele_list) {

--- a/next-app/src/components/AlleleSelectionComponent.tsx
+++ b/next-app/src/components/AlleleSelectionComponent.tsx
@@ -81,8 +81,10 @@ export default function AlelleSelectionComponent(prop: {
         setAlleleDropDownItemsArray(["..."]);
         const currentSelection = currentPicks.geneDropdown;
 
+        const encodedCurrentSelection = encodeURIComponent(currentSelection);
+
         axios
-          .get(geneSelectionEndpoint + currentSelection, axiosConfig)
+          .get(geneSelectionEndpoint + encodedCurrentSelection, axiosConfig)
           .then((response) => {
             const responseData = response.data;
             //  responseData.push("...");
@@ -91,11 +93,13 @@ export default function AlelleSelectionComponent(prop: {
           .catch((response) => console.log(response.error));
       } else {
         const currentSelection =
-          currentPicks.geneDropdown + currentPicks.subtypeDropdown + "*";
+          currentPicks.geneDropdown + currentPicks.subtypeDropdown + '*';
+
+        const encodedCurrentSelection = encodeURIComponent(currentSelection);
 
         setAlleleDropDownItemsArray([]);
         axios
-          .get(geneSelectionEndpoint + currentSelection, axiosConfig)
+          .get(geneSelectionEndpoint + encodedCurrentSelection, axiosConfig)
           .then((response) => {
             const responseData = response.data;
             // responseData.push("...");

--- a/next-app/src/components/MSAPlotPageComponent.tsx
+++ b/next-app/src/components/MSAPlotPageComponent.tsx
@@ -39,13 +39,12 @@ export default function MSAPlotPageComponent(): ReactElement {
   ]);
 
   async function AlignedSequenceData(gene: string) {
-
+    const encodedGene = encodeURIComponent(gene)
     const alignedSequenceDataEndpoint: string =
-      backendAPI + "data/sequences/alignedsequences?gene_name=" + gene;
+      backendAPI + "data/sequences/alignedsequences?gene_name=" + encodedGene;
 
-    const encodedURI = encodeURI(alignedSequenceDataEndpoint);
     await axios
-      .get(encodedURI, axiosConfig)
+      .get(alignedSequenceDataEndpoint, axiosConfig)
       .then((response) => {
         const responseData: IMSAData[] = response.data;
         let item: IMSAData;

--- a/next-app/src/components/PlotPageComponent.tsx
+++ b/next-app/src/components/PlotPageComponent.tsx
@@ -70,24 +70,24 @@ export default function PlotPage(): ReactElement {
   const [selectedAllele, setSelectedAllele] = useState<string>("");
 
   async function getGeneFreqData(allele: string) {
+    const encodedAllele = encodeURIComponent(allele)
     const alleleFrequenciesEndpoint: string = backendAPI + "data/frequencies/";
 
     const superpopulationsEndpoint: string =
-      alleleFrequenciesEndpoint + "superpopulations?allele_name=" + allele;
+      alleleFrequenciesEndpoint + "superpopulations?allele_name=" + encodedAllele;
 
-    const superPopEncodedURI = encodeURI(superpopulationsEndpoint);
     await axios
-      .get(superPopEncodedURI, axiosConfig)
+      .get(superpopulationsEndpoint, axiosConfig)
       .then((response) => {
         setSuperpopFreqAPIData(response.data);
       })
       .catch((response) => console.log(response.error));
 
     const populationsEndpoint: string =
-      alleleFrequenciesEndpoint + "populations?allele_name=" + allele;
-    const popEncodedURI = encodeURI(populationsEndpoint);
+      alleleFrequenciesEndpoint + "populations?allele_name=" + encodedAllele;
+
     await axios
-      .get(popEncodedURI, axiosConfig)
+      .get(populationsEndpoint, axiosConfig)
       .then((response) => {
         setPopFreqAPIData(response.data);
       })
@@ -95,13 +95,13 @@ export default function PlotPage(): ReactElement {
   }
 
   async function getGeneIgSNPerData(allele: string) {
+    const encodedAllele = encodeURIComponent(allele)
 
     const alleleIgSNPerDataEndpoint: string =
-      backendAPI + "data/igsnperdata?allele_name=" + allele;
+      backendAPI + "data/igsnperdata?allele_name=" + encodedAllele;
 
-    const encodedURI = encodeURI(alleleIgSNPerDataEndpoint);
     await axios
-      .get(encodedURI, axiosConfig)
+      .get(alleleIgSNPerDataEndpoint, axiosConfig)
       .then((response) => {
         const responseData: IgSNPerData = response.data;
         if (responseData.igSNPer_score || responseData.igSNPer_score === 0) {

--- a/next-app/src/constants.ts
+++ b/next-app/src/constants.ts
@@ -18,7 +18,7 @@ let backendAPI_tmp = "";
 if (typeof window !== "undefined") {
   backendAPI_tmp =
     window.location.origin === "http://localhost:3000"
-      ? "http://localhost:5000"
+      ? "http://localhost:5000/"
       : window.location.origin + "/api/";
 }
 export const backendAPI = backendAPI_tmp;


### PR DESCRIPTION
https://scilifelab.atlassian.net/browse/TP-550

fix: fixed encoding to apply to query strings fully, and only to query strings

After adding new data and testing things more thoroughly I found that endpoint requests ending with ‘+' were not working. This is due to URI queries interpreting '+’ as whitespace, and our encoding being handled poorly. Fixed encoding to only be on the actual query strings, and to encode special URI characters as well.