### PR TITLE
Fix gene names on plot pages

### DIFF
--- a/next-app/src/components/AlleleSelectionComponent.tsx
+++ b/next-app/src/components/AlleleSelectionComponent.tsx
@@ -221,7 +221,7 @@ export default function AlelleSelectionComponent(prop: {
             currentPicks.alleleDropdown ? (
               <>
                 Plot for {currentPicks.geneDropdown}
-                {currentPicks.subtypeDropdown}{currentPicks.alleleDropdown}
+                {currentPicks.subtypeDropdown}*{currentPicks.alleleDropdown}
               </>
             ) : (
               "Please select the gene type, gene and allele above"


### PR DESCRIPTION
fix: re-added asterisk in allele selection component display, somehow it was lost in a previous patch

For example: "IGHV1-18*01" was incorrectly shown as "IGHV1-1801"