### PR TITLE
other/560-add-demo-instead-of-light-version

### DIFF
--- a/next-app/package-lock.json
+++ b/next-app/package-lock.json
@@ -12,7 +12,7 @@
         "@hookform/resolvers": "^3.9.1",
         "@radix-ui/react-dropdown-menu": "^2.1.2",
         "@radix-ui/react-label": "^2.1.0",
-        "@radix-ui/react-slot": "^1.1.0",
+        "@radix-ui/react-slot": "^1.2.3",
         "@radix-ui/react-toast": "^1.2.2",
         "@socialgouv/matomo-next": "^1.9.2",
         "@tanstack/react-table": "^8.20.5",
@@ -1508,6 +1508,24 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-collection/node_modules/@radix-ui/react-slot": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.1.0.tgz",
+      "integrity": "sha512-FUCf5XMfmW4dtYl69pdS4DbxKy8nj4M7SafBgPllysxmdachynNflAdp/gCsnYWNDnge6tI9onzMp5ARYc1KNw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-compose-refs": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.0.tgz",
@@ -1727,6 +1745,24 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-menu/node_modules/@radix-ui/react-slot": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.1.0.tgz",
+      "integrity": "sha512-FUCf5XMfmW4dtYl69pdS4DbxKy8nj4M7SafBgPllysxmdachynNflAdp/gCsnYWNDnge6tI9onzMp5ARYc1KNw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-menu/node_modules/react-remove-scroll": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.6.0.tgz",
@@ -1870,6 +1906,24 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-primitive/node_modules/@radix-ui/react-slot": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.1.0.tgz",
+      "integrity": "sha512-FUCf5XMfmW4dtYl69pdS4DbxKy8nj4M7SafBgPllysxmdachynNflAdp/gCsnYWNDnge6tI9onzMp5ARYc1KNw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-roving-focus": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.0.tgz",
@@ -1917,12 +1971,28 @@
       }
     },
     "node_modules/@radix-ui/react-slot": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.1.0.tgz",
-      "integrity": "sha512-FUCf5XMfmW4dtYl69pdS4DbxKy8nj4M7SafBgPllysxmdachynNflAdp/gCsnYWNDnge6tI9onzMp5ARYc1KNw==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
       "dependencies": {
-        "@radix-ui/react-compose-refs": "1.1.0"
+        "@radix-ui/react-compose-refs": "1.1.2"
       },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slot/node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz",
+      "integrity": "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==",
+      "license": "MIT",
       "peerDependencies": {
         "@types/react": "*",
         "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"

--- a/next-app/package.json
+++ b/next-app/package.json
@@ -13,7 +13,7 @@
     "@hookform/resolvers": "^3.9.1",
     "@radix-ui/react-dropdown-menu": "^2.1.2",
     "@radix-ui/react-label": "^2.1.0",
-    "@radix-ui/react-slot": "^1.1.0",
+    "@radix-ui/react-slot": "^1.2.3",
     "@radix-ui/react-toast": "^1.2.2",
     "@socialgouv/matomo-next": "^1.9.2",
     "@tanstack/react-table": "^8.20.5",

--- a/next-app/src/app/changelog/page.tsx
+++ b/next-app/src/app/changelog/page.tsx
@@ -43,7 +43,7 @@ export default function ChangeLogPage(): ReactElement {
         <ChangeLogComponent
           title={`Version ${currentVersion}`}
           databaseUpdates={[
-            "Initial release of the light version with example data points only",
+            "Initial release of the demo version with example data points only",
           ]}
           designAndBugFixes={["Initial release"]}
           isCurrent={true}

--- a/next-app/src/app/download/page.tsx
+++ b/next-app/src/app/download/page.tsx
@@ -39,7 +39,8 @@ export default function DownloadPage(): ReactElement {
     const encodedGene = encodeURIComponent(gene);
     const fastaType =
       fastaTypeSelected === "coding" ? "" : "/" + fastaTypeSelected;
-    const fastaEndpoint = backendAPI + "fasta" + fastaType + "?file_name=" + encodedGene;
+    const fastaEndpoint =
+      backendAPI + "fasta" + fastaType + "?file_name=" + encodedGene;
     await axios
       .get(fastaEndpoint, axiosConfig)
       .then((response) => {
@@ -64,7 +65,8 @@ export default function DownloadPage(): ReactElement {
       fastaTypeSelected === "coding" ? "" : "/" + fastaTypeSelected;
     for (gene of genes) {
       const encodedGene = encodeURIComponent(gene);
-      const fastaEndpoint = backendAPI + "fasta" + fastaType + "?file_name=" + encodedGene;
+      const fastaEndpoint =
+        backendAPI + "fasta" + fastaType + "?file_name=" + encodedGene;
       await axios
         .get(fastaEndpoint, axiosConfig)
         .then((response) => {
@@ -151,7 +153,7 @@ export default function DownloadPage(): ReactElement {
             <path d="M12 13h.01" />
           </svg>
           <span className="text-sm lg:text-base">
-            You are currently exploring the light version of KIARVA. The full
+            You are currently exploring the demo version of KIARVA. The full
             version will be released once the underlying data has been
             published. Until then, the pages are visible as a demonstration but
             without full data access.

--- a/next-app/src/app/msa/page.tsx
+++ b/next-app/src/app/msa/page.tsx
@@ -28,7 +28,7 @@ export default function AminoAcidPlotPage(): ReactElement {
             <path d="M12 13h.01" />
           </svg>
           <span className="text-sm lg:text-base">
-            You are currently exploring the light version of KIARVA. The full
+            You are currently exploring the demo version of KIARVA. The full
             version will be released once the underlying data has been
             published. Until then, the pages are visible as a demonstration but
             without full data access.

--- a/next-app/src/app/page.tsx
+++ b/next-app/src/app/page.tsx
@@ -102,15 +102,15 @@ export default function HomePage(): ReactElement {
                 day: "numeric",
               })}
             </time>
-            We are excited to introduce the <b>light version</b> of our new
+            We are excited to introduce the <b>demo version</b> of our new
             research tool, designed to provide an early glimpse into the
             DSN&apos;s first dashboard. This preliminary release includes a few
             example plots to showcase the tool&apos;s analytical capabilities,
-            while the full functionality is being finalized. In this light
-            version, users can explore data visualizations but won&apos;t have
-            access to download FASTA files at this stage. The complete tool,
-            including all data and download options, will be available once the
-            research team has published their findings.
+            while the full functionality is being finalized. In this demo
+            version, users can explore data features but won&apos;t have access
+            to all data or access to download FASTA files at this stage. The
+            complete tool, including all data and download options, will be
+            available once the research team has published their findings.
           </FadeAlert>
         </div>
 

--- a/next-app/src/app/plot/layout.tsx
+++ b/next-app/src/app/plot/layout.tsx
@@ -39,7 +39,7 @@ export default function RootLayout({
             <path d="M12 13h.01" />
           </svg>
           <span className="text-sm lg:text-base">
-            You are currently exploring the light version of KIARVA. The full
+            You are currently exploring the demo version of KIARVA. The full
             version will be released once the underlying data has been
             published. Until then, the pages are visible as a demonstration but
             without full data access.

--- a/next-app/src/app/sequencesearch/page.tsx
+++ b/next-app/src/app/sequencesearch/page.tsx
@@ -99,7 +99,7 @@ export default function SequenceSearchInputForm() {
             <path d="M12 13h.01" />
           </svg>
           <span className="text-sm lg:text-base">
-            You are currently exploring the light version of KIARVA. The full
+            You are currently exploring the demo version of KIARVA. The full
             version will be released once the underlying data has been
             published. Until then, the pages are visible as a demonstration but
             without full data access.
@@ -164,8 +164,8 @@ export default function SequenceSearchInputForm() {
         />
       ) : (
         <p>
-          Sequence search is currently disabled in the light version. The
-          feature will be available in the full release.
+          Sequence search is currently disabled in the demo version. The feature
+          will be available in the full release.
         </p>
       )}
     </div>

--- a/next-app/src/components/HeaderComponent.tsx
+++ b/next-app/src/components/HeaderComponent.tsx
@@ -7,6 +7,7 @@ import { usePathname } from "next/navigation";
 import { useState } from "react";
 import clsx from "clsx";
 import { HeaderDropdown } from "@/components/ui/header-dropdown";
+import { Badge } from "@/components/ui/badge";
 
 export default function HeaderComponent() {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
@@ -44,12 +45,16 @@ export default function HeaderComponent() {
           <div className="flex justify-between items-center">
             <Link href="/">
               <div className="font-bold text-center">
-                <p className="text-2xl">KIARVA</p>
+                <div className="flex items-center justify-center gap-2">
+                  <p className="text-2xl">KIARVA</p>
+                  <Badge variant="accent">Demo</Badge>
+                </div>
                 <span className="lg:whitespace-nowrap text-xl">
                   KI Adaptive Immune Receptor Gene Variant Atlas
                 </span>
               </div>
             </Link>
+
             <button
               className="lg:hidden text-white focus:outline-none"
               onClick={() => setIsMenuOpen(!isMenuOpen)}

--- a/next-app/src/components/HeaderComponent.tsx
+++ b/next-app/src/components/HeaderComponent.tsx
@@ -8,6 +8,7 @@ import { useState } from "react";
 import clsx from "clsx";
 import { HeaderDropdown } from "@/components/ui/header-dropdown";
 import { Badge } from "@/components/ui/badge";
+import { hasCookie } from "cookies-next";
 
 export default function HeaderComponent() {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
@@ -47,7 +48,9 @@ export default function HeaderComponent() {
               <div className="font-bold text-center">
                 <div className="flex items-center justify-center gap-2">
                   <p className="text-2xl">KIARVA</p>
-                  <Badge variant="accent">Demo</Badge>
+                  {!hasCookie("password") && (
+                    <Badge variant="accent">Demo</Badge>
+                  )}
                 </div>
                 <span className="lg:whitespace-nowrap text-xl">
                   KI Adaptive Immune Receptor Gene Variant Atlas

--- a/next-app/src/components/ui/badge.tsx
+++ b/next-app/src/components/ui/badge.tsx
@@ -1,0 +1,37 @@
+import * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "@/lib/utils";
+
+const badgeVariants = cva(
+  "inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
+  {
+    variants: {
+      variant: {
+        default:
+          "border-transparent bg-primary text-primary-foreground hover:bg-primary/80",
+        secondary:
+          "border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80",
+        destructive:
+          "border-transparent bg-destructive text-destructive-foreground hover:bg-destructive/80",
+        outline: "text-foreground",
+        accent: "border-transparent bg-accent text-black hover:bg-accent/80",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+);
+
+export interface BadgeProps
+  extends React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof badgeVariants> {}
+
+function Badge({ className, variant, ...props }: BadgeProps) {
+  return (
+    <div className={cn(badgeVariants({ variant }), className)} {...props} />
+  );
+}
+
+export { Badge, badgeVariants };


### PR DESCRIPTION
## 🚀 PR: Replace "light" with "demo" terminology + Add Demo Badge

### Summary

This PR refactors the terminology across the application by replacing **"light"** with **"demo"** and introduces a **badge component** to clearly indicate demo mode. The goal is to improve user understanding and consistency in UI language.

---

### 🧾 What’s Changed

#### ✅ Feature Enhancements
- **Added `Badge` component** using `shadcn/ui` styling.
- **Introduced a "Demo" badge** next to the KIARVA title in the header.
- **Conditional display**: Demo badge is only shown **when no password is entered** (`cookies-next` check).

#### ✏️ Terminology Update
- Replaced all instances of `"light version"` with `"demo version"`:
  - Home page
  - MSA page
  - Sequence Search page
  - Plot layout
  - Changelog entry
  - Download alert

#### 📦 Package Updates
- Updated dependency:
  - `@radix-ui/react-slot`: `^1.1.0` → `^1.2.3`

---

### 📊 Code Stats

- **139 additions**
- **22 deletions**

---

### 🗂️ Affected Files

- `next-app/package.json`, `next-app/package-lock.json`
- `src/app/page.tsx`
- `src/app/msa/page.tsx`
- `src/app/plot/layout.tsx`
- `src/app/sequencesearch/page.tsx`
- `src/app/changelog/page.tsx`
- `src/app/download/page.tsx`
- `src/components/HeaderComponent.tsx`
- ➕ `src/components/ui/badge.tsx` (new)

---

### 🔍 Motivation

These updates ensure that the app’s limited-access mode is consistently branded as a **"Demo" version**, aligning better with user expectations and preparing the app for its future full release.
