### PR TITLE
Ad-hoc/MatomoInit fix

### DIFF
--- a/next-app/src/components/MatomoInit.tsx
+++ b/next-app/src/components/MatomoInit.tsx
@@ -5,7 +5,7 @@ import { init } from "@socialgouv/matomo-next";
 
 export default function MatomoInit() {
   useEffect(() => {
-    if (window.location.origin === "https://kiarva.scilifelab.se") {
+    if (window.location.origin.includes("kiarva.scilifelab.se")) {
       init({
           url: 'https://matomo.dc.scilifelab.se/', 
           siteId: '12',


### PR DESCRIPTION
fix: changed the way the matomo init components detects that its coming from the prod instance of the app slightly, should be more flexible.

Previous version only inits Matomo if the current window origin is exactly the KIARVA start page, new version just checks that current window origin URI contains kiarva.scilifelab.se. Not 100% sure it's necessary but I think it might be better for tracking subpages and so on (and in the worst case it makes no difference from old version.