### PR TITLE
563/add translated fastas

### DIFF
--- a/next-app/src/app/download/page.tsx
+++ b/next-app/src/app/download/page.tsx
@@ -37,10 +37,8 @@ export default function DownloadPage(): ReactElement {
 
   async function downloadGeneFasta(gene: string) {
     const encodedGene = encodeURIComponent(gene);
-    const fastaType =
-      fastaTypeSelected === "coding" ? "" : "/" + fastaTypeSelected;
     const fastaEndpoint =
-      backendAPI + "fasta" + fastaType + "?file_name=" + encodedGene;
+      backendAPI + "fasta/" + fastaTypeSelected + "?file_name=" + encodedGene;
     await axios
       .get(fastaEndpoint, axiosConfig)
       .then((response) => {
@@ -61,12 +59,10 @@ export default function DownloadPage(): ReactElement {
   async function downloadGeneFastaZip(genes: string[]) {
     const zip = new JSZip();
     let gene: string;
-    const fastaType =
-      fastaTypeSelected === "coding" ? "" : "/" + fastaTypeSelected;
     for (gene of genes) {
       const encodedGene = encodeURIComponent(gene);
       const fastaEndpoint =
-        backendAPI + "fasta" + fastaType + "?file_name=" + encodedGene;
+        backendAPI + "fasta/" + fastaTypeSelected + "?file_name=" + encodedGene;
       await axios
         .get(fastaEndpoint, axiosConfig)
         .then((response) => {
@@ -117,8 +113,6 @@ export default function DownloadPage(): ReactElement {
       downloadGeneFastaZip(selectionArr);
     }
   }
-
-  // Combine the selection arrays and use them when the download button is pressed
 
   useEffect(() => {
     if (hasCookie("password")) {
@@ -213,10 +207,9 @@ export default function DownloadPage(): ReactElement {
             </span>
           </label>
 
-          {/* Once the fasta type is available, only delete the className part from cursor-not-allowed */}
           <label
-            className="flex rounded-md px-2 py-2 my-3 transition-all duration-300 hover:bg-neutral cursor-pointer cursor-not-allowed pointer-events-none opacity-50"
-            onClick={() => setFastaTypeSelected("aminoacids")}
+            className="flex rounded-md px-2 py-2 my-3 transition-all duration-300 hover:bg-neutral cursor-pointer"
+            onClick={() => setFastaTypeSelected("translated")}
           >
             <input type="radio" name="fastaRadio" className="radio" />
             <span className="pl-2">Translated V gene sequences</span>
@@ -231,11 +224,12 @@ export default function DownloadPage(): ReactElement {
           geneSegment="IGH"
           geneObjectArray={[
             { name: "IGHV", isAvailable: true },
-            { name: "IGHD", isAvailable: true },
+            { name: "IGHD", isAvailable: fastaTypeSelected === "coding" || fastaTypeSelected === "genomic" },
             { name: "IGHJ", isAvailable: fastaTypeSelected === "coding" },
             { name: "IGH constant", isAvailable: false },
           ]}
           setPropsSelectionArray={setIghSelectionArray}
+          radialSelected={fastaTypeSelected}
         ></DownloadBoxComponent>
         {/* <DownloadBoxComponent
           geneSegment="IGK"

--- a/next-app/src/app/download/page.tsx
+++ b/next-app/src/app/download/page.tsx
@@ -17,7 +17,7 @@ import { Download } from "lucide-react";
 
 export default function DownloadPage(): ReactElement {
   // State to keep track of the selected type of fasta file
-  const [fastaTypeSelected, setFastaTypeSelected] = useState("coding");
+  const [fastaTypeSelected, setFastaTypeSelected] = useState("genomic");
 
   // States to keep track of the selected genes for each gene segment
   const [ighSelectionArray, setIghSelectionArray] = useState<string[]>([]);
@@ -45,12 +45,13 @@ export default function DownloadPage(): ReactElement {
         const responseData: Blob = response.data;
         fileDownload(
           responseData,
-          gene +
-            "-" +
+            "Homo-sapiens_Ig_Heavy_" + 
+            gene[gene.length-1] +
+            "_" +
             fastaTypeSelected +
-            "-v" +
+            "_v" +
             currentVersionFormatted +
-            ".fasta"
+            ".fasta",
         );
       })
       .catch((response) => console.log(response.error));
@@ -68,10 +69,11 @@ export default function DownloadPage(): ReactElement {
         .then((response) => {
           const responseData: Blob = response.data;
           zip.file(
-            gene +
-              "-" +
+              "Homo-sapiens_Ig_Heavy_" + 
+              gene[gene.length-1] +
+              "_" +
               fastaTypeSelected +
-              "-v" +
+              "_v" +
               currentVersionFormatted +
               ".fasta",
             responseData
@@ -83,9 +85,9 @@ export default function DownloadPage(): ReactElement {
       function (blob) {
         fileDownload(
           blob,
-          "kiarva-" +
+          "Homo-sapiens_Ig_" +
             fastaTypeSelected +
-            "-v" +
+            "_v" +
             currentVersionFormatted +
             "-fastas.zip"
         );
@@ -186,7 +188,7 @@ export default function DownloadPage(): ReactElement {
         <div>
           <label
             className="flex rounded-md px-2 py-2 my-3 transition-all duration-300 hover:bg-neutral cursor-pointer"
-            onClick={() => setFastaTypeSelected("coding")}
+            onClick={() => setFastaTypeSelected("genomic")}
           >
             <input
               type="radio"
@@ -199,7 +201,7 @@ export default function DownloadPage(): ReactElement {
 
           <label
             className="flex rounded-md px-2 py-2 my-3 transition-all duration-300 hover:bg-neutral cursor-pointer"
-            onClick={() => setFastaTypeSelected("genomic")}
+            onClick={() => setFastaTypeSelected("genomic_fl")}
           >
             <input type="radio" name="fastaRadio" className="radio" />
             <span className="pl-2">
@@ -224,8 +226,8 @@ export default function DownloadPage(): ReactElement {
           geneSegment="IGH"
           geneObjectArray={[
             { name: "IGHV", isAvailable: true },
-            { name: "IGHD", isAvailable: fastaTypeSelected === "coding" || fastaTypeSelected === "genomic" },
-            { name: "IGHJ", isAvailable: fastaTypeSelected === "coding" },
+            { name: "IGHD", isAvailable: fastaTypeSelected === "genomic" || fastaTypeSelected === "genomic_fl" },
+            { name: "IGHJ", isAvailable: fastaTypeSelected === "genomic" },
             { name: "IGH constant", isAvailable: false },
           ]}
           setPropsSelectionArray={setIghSelectionArray}

--- a/next-app/src/components/DownloadBoxComponent.tsx
+++ b/next-app/src/components/DownloadBoxComponent.tsx
@@ -8,6 +8,7 @@ const DownloadBoxComponent: React.FC<DownloadBoxComponentProps> = ({
   geneSegment,
   geneObjectArray,
   setPropsSelectionArray,
+  radialSelected
 }) => {
   // State to track if the whole gene segment is selected
   const [wholeGeneSegmentSelected, setWholeGeneSegmentSelected] =
@@ -20,6 +21,11 @@ const DownloadBoxComponent: React.FC<DownloadBoxComponentProps> = ({
   const availableGeneObjectArray = geneObjectArray.filter(
     (gene) => gene.isAvailable
   );
+
+  useEffect(() => {
+    setGenesSelectedArray([]);
+    setWholeGeneSegmentSelected(false);
+  }, [radialSelected]);
 
   // Effect to update selected genes array when wholeGeneSegmentSelected changes
   useEffect(() => {

--- a/next-app/src/interfaces/types.ts
+++ b/next-app/src/interfaces/types.ts
@@ -104,6 +104,7 @@ export type DownloadBoxComponentProps = {
   geneSegment: string;
   geneObjectArray: GeneObject[];
   setPropsSelectionArray: (propsSelectionArray: string[]) => void;
+  radialSelected: string;
 };
 
 export interface GeneObject {


### PR DESCRIPTION
https://scilifelab.atlassian.net/browse/TP-563

feature and fix: added translated fastas radial option. Also fixed so that genes are deselected when switching radial options, previously genes that were supposed to be disabled stayed selected

Had to add radial selection as prop in child component to get it to react to the change, but seems to be working fine. It works by wiping the current gene selection array and disabling "whole genome selected" if the radial option changes.

Was also able to simplify backend URI string since the endpoint naming became more consistent.

Might have to rename some of the endpoints or options depending on Hedestam's feedback before merging.