### PR TITLE
fix/611: Sequence search fix

### DIFF
--- a/next-app/src/app/sequencesearch/page.tsx
+++ b/next-app/src/app/sequencesearch/page.tsx
@@ -158,10 +158,13 @@ export default function SequenceSearchInputForm() {
         </Form>
       </div>
       {hasCookie("password") ? (
+        sequenceData[0].allele ?
         <SequenceSearchComponent
           sequenceData={sequenceData}
           searchTermLength={searchTermLength}
         />
+        :
+        <p>No matches in database for the requested sequence.</p>
       ) : (
         <p>
           Sequence search is currently disabled in the demo version. The feature


### PR DESCRIPTION
https://scilifelab.atlassian.net/browse/TP-611

fix: Added a condition that displays a message if the sequence a user tries to search for in sequence search does not exist in database.

The actual bug that was reported was due to a problem in the backend which was fixed there, but decided that it makes sense to convey to the user that their sequence was not found. Used no styling (only a <p> with the text) so could be improved upon in the future if deemed necessary.