### PR TITLE
fix/adhoc: fix sequence search bug

### DIFF
--- a/next-app/src/app/sequencesearch/page.tsx
+++ b/next-app/src/app/sequencesearch/page.tsx
@@ -158,13 +158,15 @@ export default function SequenceSearchInputForm() {
         </Form>
       </div>
       {hasCookie("password") ? (
-        sequenceData[0].allele ?
-        <SequenceSearchComponent
-          sequenceData={sequenceData}
-          searchTermLength={searchTermLength}
-        />
-        :
-        <p>No matches in database for the requested sequence.</p>
+        sequenceData[0] &&
+          (sequenceData[0].allele ? 
+          <SequenceSearchComponent
+            sequenceData={sequenceData}
+            searchTermLength={searchTermLength}
+          />
+          :
+          <p>No matches in database for the requested sequence.</p>
+          )
       ) : (
         <p>
           Sequence search is currently disabled in the demo version. The feature


### PR DESCRIPTION
fix: fixed a bug where a component of sequence search tried to access sequenceData[0].allele, which doesn't exist at a fresh reload, causing the page to crash. Now first checks if sequenceData[0] is empty before that.