### PR TITLE
682/feature: add option to download frequency plot data

### DIFF
--- a/next-app/src/components/AlleleSelectionComponent.tsx
+++ b/next-app/src/components/AlleleSelectionComponent.tsx
@@ -8,6 +8,8 @@ import axios from "axios";
 import DropdownComponent from "@/components/DropdownComponent";
 import { getCookie, hasCookie } from "cookies-next";
 import { IAlleleDropDownConfig } from "@/interfaces/types";
+import { BUTTON_TYPE_ONE } from "@/constants";
+import DownloadPlotData from "./DownloadPlotData";
 
 // Main function to render the PlotPage component
 export default function AlelleSelectionComponent(prop: {
@@ -232,25 +234,34 @@ export default function AlelleSelectionComponent(prop: {
         role="status"
         aria-live="polite"
       >
-        <p className="text-neutral-content text-xl font-semibold">
+        <div className="lg:w-1/2 md:w-1/2">
           {prop.plotType === "aminoAcidMSA" &&
           currentPicks.geneDropdown &&
           currentPicks.subtypeDropdown ? (
-            <>
+            <p className="text-neutral-content text-xl font-semibold">
               Sequence alignments for {currentPicks.geneDropdown}
               {currentPicks.subtypeDropdown}
-            </>
+            </p>
           ) : currentPicks.geneDropdown &&
             currentPicks.subtypeDropdown &&
             currentPicks.alleleDropdown ? (
-            <>
-              Plot for {currentPicks.geneDropdown}
-              {currentPicks.subtypeDropdown}*{currentPicks.alleleDropdown}
-            </>
+            <div className="flex justify-evenly">
+              <p className="text-neutral-content text-xl font-semibold p-2">
+                Plot for {currentPicks.geneDropdown}
+                {currentPicks.subtypeDropdown}*{currentPicks.alleleDropdown}
+              </p>
+              <DownloadPlotData 
+                alleleName={currentPicks.geneDropdown+currentPicks.subtypeDropdown+"*"+currentPicks.alleleDropdown}
+                tableType={prop.plotType}
+              >
+              </DownloadPlotData>
+            </div>
           ) : (
-            "Please select the gene type, gene and allele above"
+            <p className="text-neutral-content text-xl font-semibold">
+              Please select the gene type, gene and allele above
+            </p>
           )}
-        </p>
+        </div>
       </div>
     </section>
   );

--- a/next-app/src/components/AlleleSelectionComponent.tsx
+++ b/next-app/src/components/AlleleSelectionComponent.tsx
@@ -8,7 +8,6 @@ import axios from "axios";
 import DropdownComponent from "@/components/DropdownComponent";
 import { getCookie, hasCookie } from "cookies-next";
 import { IAlleleDropDownConfig } from "@/interfaces/types";
-import { BUTTON_TYPE_ONE } from "@/constants";
 import DownloadPlotData from "./DownloadPlotData";
 
 // Main function to render the PlotPage component

--- a/next-app/src/components/DownloadPlotData.tsx
+++ b/next-app/src/components/DownloadPlotData.tsx
@@ -1,0 +1,73 @@
+'use client';
+
+import { backendAPI } from '@/constants';
+import { Button } from "@/components/ui/button";
+import axios from 'axios';
+import { getCookie, hasCookie } from 'cookies-next';
+import fileDownload from 'js-file-download';
+import { ReactElement, useEffect, useState } from 'react';
+
+// Component that fetches frequency plot data from API and allows user to download it
+export default function DownloadPlotData(prop: {
+        alleleName: string;
+        tableType: string;
+    }): ReactElement {
+    const [axiosConfig, setAxiosConfig] = useState({
+        headers: {
+          "X-api-key": "",
+          "Content-Type": "attachment",
+        },
+    });
+
+    async function handleDownload() {
+        const encodedAlleleName = encodeURIComponent(prop.alleleName);
+        const tableTypeURI = prop.tableType == "genomicFreqPlot" ? "frequencies" : "aminoacidfrequencies";
+        const tableVariableName = prop.tableType == "genomicFreqPlot" ? "allele_name" : "aa_allele_name";
+        const tableEndpoint =
+        backendAPI + "data/" + tableTypeURI + "/table?"+tableVariableName+"=" + encodedAlleleName;
+        const tableFileNameSuffix = prop.tableType == "genomicFreqPlot" ? "genomic" : "aminoacid"; 
+        const tableFileName = prop.alleleName.replace("*", "_").replace("/","_") + "-" + tableFileNameSuffix +"_frequencies.tsv";
+        await axios
+            .get(tableEndpoint, axiosConfig)
+            .then((response) => {
+                const responseData: Blob = response.data;
+                fileDownload(
+                responseData,
+                tableFileName
+                );
+            })
+            .catch((response) => console.log(response.error));
+    }
+
+    useEffect(() => {
+        if (hasCookie("password")) {
+        setAxiosConfig({
+            headers: {
+            "X-api-key": getCookie("password") as string,
+            "Content-Type": "attachment",
+            },
+        });
+        }
+    }, []);
+
+
+    return (
+        <>
+            <section aria-label="Download actions">
+                <div className="flex justify-center py-8 lg:py-0">
+                {/* Delete the button disabled and className when officially launching */}
+                <Button
+                    variant="default"
+                    onClick={handleDownload}
+                    disabled={!hasCookie("password")}
+                    className={
+                    "opacity-50" + (!hasCookie("password") && " cursor-not-allowed")
+                    }
+                >
+                    Download frequency table
+                </Button>
+                </div>
+            </section>
+        </>
+    );
+}


### PR DESCRIPTION
https://scilifelab.atlassian.net/browse/TP-682

feature: added a button to download frequency plot data once a selection has been made

A simple download feature using a button, based on similar functionality in previous components and pages. For now works like the download in regards to access (button disabled if password cookie doesn't exist, API expects API-key with password).