### PR TITLE
691/feature: add responsive sizing for plot page

### DIFF
--- a/next-app/src/components/FrequencyPlotComponent.tsx
+++ b/next-app/src/components/FrequencyPlotComponent.tsx
@@ -10,6 +10,7 @@ import Plotly, { Datum, Layout } from "plotly.js";
 import createPlotlyComponent from "react-plotly.js/factory";
 import {
   IGeneFrequencyData,
+  IPlotDimensions,
   IPopulationRegion,
   ISuperpopulationColors,
 } from "@/interfaces/types";
@@ -97,10 +98,24 @@ export default function FrequencyPlotComponent(prop: {
   const data = [...superpopulationTraces, ...populationTraces];
 
   const [isLargeScreen, setIsLargeScreen] = useState(true);
+  const [plotDimensions, setPlotDimensions] = useState<IPlotDimensions>({height: 500, width: 1250});
 
   useEffect(() => {
     const handleResize = () => {
-      setIsLargeScreen(window.innerWidth >= 1280);
+      if (window.innerWidth < 750){
+        setIsLargeScreen(false);
+      } else {
+        setIsLargeScreen(true);
+      }
+      if (window.innerWidth >= 750 && window.innerWidth < 1000) {
+        setPlotDimensions({height: 400, width: 800});
+      }
+      else if (window.innerWidth < 1280) {
+        setPlotDimensions({height: 400, width: 1000});
+      }
+      else if (window.innerWidth >= 1280) {
+        setPlotDimensions({height: 500, width: 1250});
+      }
     };
     window.addEventListener("resize", handleResize);
     handleResize(); // Initial check
@@ -108,8 +123,8 @@ export default function FrequencyPlotComponent(prop: {
   }, []);
 
   const layout: Partial<Layout> = {
-    height: 500,
-    width: 1250,
+    height: plotDimensions.height,
+    width: plotDimensions.width,
     xaxis: {
       showticklabels: false,
     },
@@ -171,9 +186,8 @@ export default function FrequencyPlotComponent(prop: {
           />
         </svg>
         <p>
-          Error: Plots can only be displayed on a 13-inch screen and bigger.
-          Please resize your browser window to view the plots or use a laptop or
-          desktop computer.
+          Error: Plots can not be displayed on screens of this size.
+          Please resize your browser window to view the plots or use a device with a larger screen.
         </p>
       </aside>
     );

--- a/next-app/src/components/MSAPlotPageComponent.tsx
+++ b/next-app/src/components/MSAPlotPageComponent.tsx
@@ -158,7 +158,7 @@ export default function MSAPlotPageComponent(): ReactElement {
           >
             MAFFT v7.525
           </a>
-          . Translated sequences are based off of the MAFFT nucleotide sequence alignment output, 
+          . Translated sequence alignments are based off of the MAFFT output for the nucleotide sequences, 
           but aligned with a{" "}
           <a
             className={`${LINK_CLASSES} italic`}

--- a/next-app/src/interfaces/types.ts
+++ b/next-app/src/interfaces/types.ts
@@ -103,3 +103,8 @@ export type IMSAData = {
   sequence_nt: string;
   sequence_aa: string;
 };
+
+export type IPlotDimensions = {
+  height: number;
+  width: number;
+};


### PR DESCRIPTION
https://scilifelab.atlassian.net/browse/TP-691

feature: adding (somewhat arbitrary, but tested) cutoffs allowing viewing the full frequency plots at smaller screen sizes (but not mobile). Also did some minor edits to texts.

I tried some different widths for cutoffs, and different width and height combinations. The current settings are somewhat arbitrary as mentioned, but it gave a decent balance where you can always see the full plot until you reach below 750p width. At sizes below 750p width, the same behaviour as before is used (displaying a message saying the screen is too small to view plots).