### PR TITLE
other/641-update-footer-similar-to-pmp

### DIFF
--- a/next-app/package-lock.json
+++ b/next-app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kiarva-frontend",
-  "version": "0.10.4",
+  "version": "0.10.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kiarva-frontend",
-      "version": "0.10.4",
+      "version": "0.10.5",
       "dependencies": {
         "@headlessui/react": "^2.1.9",
         "@hookform/resolvers": "^3.9.1",

--- a/next-app/package.json
+++ b/next-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kiarva-frontend",
-  "version": "0.10.4",
+  "version": "0.10.5",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/next-app/src/app/layout.tsx
+++ b/next-app/src/app/layout.tsx
@@ -16,6 +16,7 @@ export default function RootLayout({
   return (
     <html lang="en" data-theme="light">
       <body>
+        <div id="top" aria-hidden="true" />
         <MatomoInit></MatomoInit>
         <HeaderComponent />
         {children}

--- a/next-app/src/components/DisplayAppVersion.tsx
+++ b/next-app/src/components/DisplayAppVersion.tsx
@@ -4,7 +4,13 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { LINK_CLASSES } from "@/constants";
+
+function toHref(value: string) {
+  const v = value.trim();
+  if (!v) return "#";
+  if (/^https?:\/\//i.test(v)) return v;
+  return `https://${v}`;
+}
 
 export default function FooterVersion() {
   const [frontendImage, setFrontendImage] = useState<string | null>(null);
@@ -20,48 +26,36 @@ export default function FooterVersion() {
   }, []);
 
   return (
-    <nav
-      aria-label="Footer extra navigation"
-      className="grid grid-cols-2 lg:grid-cols-4 gap-4 lg:gap-8"
-    >
-      <ul className="contents">
-        <li>
-          <a href={"https://" + frontendImage || "/"}>
-            <span className={`text-info-content/70 text-sm ${LINK_CLASSES}`}>
-              Frontend version: {frontendImage?.split(":")[1] || "n/a"}
-            </span>
-          </a>
-        </li>
-        <li>
-          <a href={"https://" + backendImage || "/"}>
-            <span className={`text-info-content/70 text-sm ${LINK_CLASSES}`}>
-              Backend version: {backendImage?.split(":")[1] || "n/a"}
-            </span>
-          </a>
-        </li>
-        <li>
-          <a
-            href="https://precision-medicine-portal.scilifelab.se/privacy"
-            rel="noopener noreferrer"
-            target="_blank"
-          >
-            <span className={`text-info-content/70 text-sm ${LINK_CLASSES}`}>
-              Privacy policy
-            </span>
-          </a>
-        </li>
-        <li>
-          <a
-            href="https://precision-medicine-portal.scilifelab.se/citation-and-license"
-            rel="noopener noreferrer"
-            target="_blank"
-          >
-            <span className={`text-info-content/70 text-sm ${LINK_CLASSES}`}>
-              Citation and license
-            </span>
-          </a>
-        </li>
-      </ul>
-    </nav>
+    <div className="flex flex-col gap-1 items-start lg:items-end">
+      {frontendImage ? (
+        <a
+          href={toHref(frontendImage)}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="hover:underline underline-offset-4 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-foreground/50 rounded-sm"
+          aria-label={`Frontend version ${frontendImage.split(":")[1] || ""}`}
+        >
+          Frontend version: {frontendImage.split(":")[1] || "n/a"}
+          <span className="sr-only"> (opens in a new tab)</span>
+        </a>
+      ) : (
+        <span>Frontend version: n/a</span>
+      )}
+
+      {backendImage ? (
+        <a
+          href={toHref(backendImage)}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="hover:underline underline-offset-4 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-foreground/50 rounded-sm"
+          aria-label={`Backend version ${backendImage.split(":")[1] || ""}`}
+        >
+          Backend version: {backendImage.split(":")[1] || "n/a"}
+          <span className="sr-only"> (opens in a new tab)</span>
+        </a>
+      ) : (
+        <span>Backend version: n/a</span>
+      )}
+    </div>
   );
 }

--- a/next-app/src/components/FooterComponent.tsx
+++ b/next-app/src/components/FooterComponent.tsx
@@ -1,77 +1,118 @@
-// Should be server component, has no user interactivity.
-
-"use client";
-
-import { ReactElement } from "react";
-import { ILink } from "@/interfaces/types";
-import { LINK_CLASSES } from "@/constants";
 import Link from "next/link";
-import { usePathname } from "next/navigation";
 import DisplayAppVersion from "@/components/DisplayAppVersion";
-import { Button } from "@/components/ui/button";
 
-const footerBackground = "images/hedestamFooterImage.png";
+type FooterLink = { label: string; href: string };
 
-export default function FooterComponent(): ReactElement {
-  const links: { [id: string]: ILink } = {
-    l1: {
-      text: "Download FASTA files",
-      classes: LINK_CLASSES,
-      link: "/download",
-    },
-    l2: {
-      text: "Population frequencies",
-      classes: LINK_CLASSES,
-      link: "/plot",
-    },
-    l3: { text: "Methodology", classes: LINK_CLASSES, link: "/methodology" },
-    l4: { text: "Change log", classes: LINK_CLASSES, link: "/changelog" },
-    l5: { text: "Publications", classes: LINK_CLASSES, link: "/publications" },
-    l6: { text: "About", classes: LINK_CLASSES, link: "/about" },
-  };
+const toolsLinks: FooterLink[] = [
+  { label: "Download", href: "/download" },
+  { label: "Population frequencies", href: "/plot" },
+  { label: "Alignments", href: "/msa" },
+  { label: "Sequence search", href: "/sequencesearch" },
+];
 
-  const currentPath = usePathname();
+const projectLinks: FooterLink[] = [
+  { label: "About", href: "/about" },
+  { label: "Methodology", href: "/methodology" },
+  { label: "Publications", href: "/publications" },
+  { label: "Change log", href: "/changelog" },
+];
 
+const externalLinks: Array<FooterLink & { external?: boolean }> = [
+  {
+    label: "Privacy policy",
+    href: "https://precision-medicine-portal.scilifelab.se/privacy",
+    external: true,
+  },
+  {
+    label: "Citation and license",
+    href: "https://precision-medicine-portal.scilifelab.se/citation-and-license",
+    external: true,
+  },
+];
+
+function FooterLinkList({
+  title,
+  links,
+}: {
+  title: string;
+  links: FooterLink[];
+}) {
   return (
-    <footer className="relative bg-primary">
-      <img
-        className="h-64 w-full object-cover"
-        src={footerBackground}
-        alt=""
-        aria-hidden="true"
-      />
-      <div
-        className="absolute inset-0 bg-gray-700 opacity-85"
-        aria-hidden="true"
-      ></div>
-      <div className="absolute inset-0 footer footer-center pt-4 lg:pt-10 px-4 lg:px-36 2xl:max-w-screen-2xl 2xl:mx-auto">
-        <section className="flex flex-col items-center justify-center space-y-4 z-10">
-          <h2 className="sr-only">Footer navigation</h2>
-          <p className="text-primary-content text-base lg:text-lg font-semibold">
-            Please visit the other pages of KIARVA
-          </p>
+    <div>
+      <h3 className="text-sm font-semibold tracking-wide text-primary-foreground">
+        {title}
+      </h3>
+      <ul className="mt-4 space-y-3">
+        {links.map((l) => (
+          <li key={l.href}>
+            <Link
+              href={l.href}
+              className="text-sm text-primary-foreground/80 hover:text-primary-foreground hover:underline underline-offset-4 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-foreground/50 rounded-sm"
+            >
+              {l.label}
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+export default function FooterComponent() {
+  return (
+    <footer className="border-t border-primary/30 bg-primary text-primary-foreground">
+      <div className="mx-auto max-w-screen-2xl px-6 py-12">
+        <h2 id="footer-navigation-heading" className="sr-only">
+          Footer navigation
+        </h2>
+        <div className="grid gap-10 md:grid-cols-12">
+          <section className="md:col-span-4">
+            <Link
+              href="/#top"
+              className="inline-flex items-center gap-2 font-bold text-lg hover:underline underline-offset-4 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-foreground/50 rounded-sm"
+              aria-label="KIARVA home"
+            >
+              KIARVA
+            </Link>
+            <p className="mt-3 text-sm text-primary-foreground/80">
+              KI Adaptive Immune Receptor Gene Variant Atlas.
+            </p>
+          </section>
+
           <nav
-            className="grid grid-flow-row grid-cols-2 lg:grid-flow-col gap-2 lg:gap-4"
-            aria-label="Footer navigation"
+            className="md:col-span-8 grid grid-cols-2 gap-8 sm:grid-cols-3"
+            aria-labelledby="footer-navigation-heading"
           >
-            {Object.keys(links)
-              .filter((key) => links[key].link !== currentPath) // Filter out the current page link
-              .map((key) => (
-                <Button
-                  key={key}
-                  variant="default"
-                  size="sm"
-                  asChild
-                  onClick={() => window.scrollTo(0, 0)}
-                >
-                  <Link href={links[key].link} rel="noopener noreferrer">
-                    {links[key].text}
-                  </Link>
-                </Button>
-              ))}
+            <FooterLinkList title="Tools" links={toolsLinks} />
+            <FooterLinkList title="Project" links={projectLinks} />
+            <div>
+              <h3 className="text-sm font-semibold tracking-wide text-primary-foreground">
+                Policies
+              </h3>
+              <ul className="mt-4 space-y-3">
+                {externalLinks.map((l) => (
+                  <li key={l.href}>
+                    <a
+                      href={l.href}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-sm text-primary-foreground/80 hover:text-primary-foreground hover:underline underline-offset-4 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-foreground/50 rounded-sm"
+                    >
+                      {l.label}
+                      <span className="sr-only"> (opens in a new tab)</span>
+                    </a>
+                  </li>
+                ))}
+              </ul>
+            </div>
           </nav>
-          <DisplayAppVersion />
-        </section>
+        </div>
+
+        <div className="mt-10 border-t border-primary-foreground/20 pt-6 flex justify-start lg:justify-end">
+          <div className="text-xs text-primary-foreground/70">
+            <DisplayAppVersion />
+          </div>
+        </div>
       </div>
     </footer>
   );

--- a/next-app/src/components/HeaderComponent.tsx
+++ b/next-app/src/components/HeaderComponent.tsx
@@ -51,7 +51,10 @@ export default function HeaderComponent() {
       <div className="text-white 2xl:max-w-screen-2xl 2xl:mx-auto">
         <div className="flex flex-col lg:flex-row lg:items-center lg:justify-between py-4 px-6">
           <div className="flex justify-between items-center">
-            <Link href="/" className="font-bold text-center">
+            <Link
+              href="/#top"
+              className="font-bold text-center rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/50"
+            >
               <div className="flex items-center justify-center gap-2">
                 <h1 className="text-2xl">KIARVA</h1>
                 {showDemoBadge && <Badge variant="accent">Demo</Badge>}
@@ -62,7 +65,7 @@ export default function HeaderComponent() {
             </Link>
 
             <button
-              className="lg:hidden text-white focus:outline-none"
+              className="lg:hidden text-white rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/50"
               onClick={() => setIsMenuOpen(!isMenuOpen)}
               aria-expanded={isMenuOpen}
               aria-controls="main-navigation"
@@ -108,7 +111,7 @@ export default function HeaderComponent() {
                   <Link
                     className={clsx(
                       link.classes,
-                      "block",
+                      "block rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/50",
                       pathname === link.link && "underline"
                     )}
                     href={link.link}


### PR DESCRIPTION
## Summary

This PR modernizes the KIARVA footer to better match the PMP/portal look and improves the footer’s information architecture and accessibility.

## What changed

- **Footer redesign**
  - Grouped links into clear sections (**Tools**, **Project**, **Policies**)
  - Updated to a responsive, modern grid layout
  - Switched footer background to solid **primary** (removed gradient) for a cleaner, more professional look

- **Navigation UX**
  - Footer brand link now points to `/#top` so clicking **KIARVA** reliably scrolls to the top
  - Added a `#top` anchor in the root layout

- **Versions + external links**
  - Improved version link handling and URL construction
  - External links (policies + versions) include screen-reader text indicating they **open in a new tab**

- **Accessibility**
  - Added an `sr-only` footer heading and connected it to the footer nav via `aria-labelledby`
  - Ensured visible keyboard focus states on footer links

## Notes

- Footer remains a **server component** (minimal client JS); version fetching stays isolated in `DisplayAppVersion` as a client component.