### PR TITLE
Prepare for release v0.15.1

### DIFF
--- a/next-app/src/app/citation-and-license/page.tsx
+++ b/next-app/src/app/citation-and-license/page.tsx
@@ -1,0 +1,238 @@
+"use client";
+
+import { ReactElement } from "react";
+
+import { LastUpdated } from "@/components/common/last-updated";
+
+import Title from "@/components/common/title";
+
+export default function CitationAndLicensePage(): ReactElement {
+  return (
+    <div className="container max-w-4xl mx-auto py-8">
+      <div
+        className="flex flex-col gap-y-4"
+        aria-label="Citation and license information"
+      >
+        <Title level={1}>Citation and license</Title>
+        <p role="doc-abstract">
+          In line with the principles of FAIR and Open Science, we encourage the
+          reuse and recognition of material made available on KIARVA for non-commercial purposes. This page 
+          provides guidance on how to cite the portal and outlines the licensing 
+          conditions for using its content and code.
+        </p>
+        <Title level={2} aria-label="Information about citing the website">
+          Citing the website
+        </Title>
+        <p>
+          The information on KIARVA is continuously updated. Therefore, it
+          is important to refer to specific versions (or to provide access
+          dates) when citing.
+        </p>
+        <Title level={3} aria-label="Citation guidance for research community">
+          Research Community
+        </Title>
+        <p>
+          Researchers are encouraged to cite KIARVA and
+          its underlying code in scientific publications.
+        </p>
+        <Title level={4}>Citing website content</Title>
+        <p>
+          The <strong>Research Resource Identifier (RRID)</strong> for KIARVA is{" "}
+          <strong>
+            <a
+              href="https://rrid.site/data/record/nlx_144509-1/SCR_026682/resolver"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-primary underline focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 rounded"
+              aria-label="RRID SCR_026682 (opens in new tab)"
+            >
+              SCR_026682
+            </a>
+          </strong>
+          . Using this identifier helps track reuse and ensures proper
+          attribution.
+          <br />
+          Moreover, the <strong>version numbers</strong> for the backend and frontend are available at the
+          bottom of any page on KIARVA. Two examples of how to cite the portal are
+          provided below.
+        </p>
+        <ul
+          className="list-disc pl-4"
+          role="list"
+          aria-label="Citation examples"
+        >
+          <li role="listitem">
+            In-text citation example (APA style): KIARVA,
+            Karolinska Institutet and SciLifeLab Data Centre, <i>version number</i>, RRID: SCR_026682.
+            (Access date: date of access).
+          </li>
+          <li role="listitem">
+            Reference list example: KIARVA (
+            <i>access date</i>), Karolinska Institutet and SciLifeLab Data Centre, version (version
+            number) from{" "}
+            <a
+              href="https://kiarva.scilifelab.se"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-primary underline focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 rounded"
+              aria-label="KIARVA website (opens in new tab)"
+            >
+              https://kiarva.scilifelab.se
+            </a>
+            , RRID: SCR_026682.
+          </li>
+        </ul>
+        <p>
+          When citing a specific page with a listed author, date or DOI, include
+          that information along with the RRID.
+        </p>
+        <Title level={3} aria-label="Citation guidance for journalists">
+          Journalists
+        </Title>
+        <p>
+          Journalists are welcome to reuse text, images, and other content from
+          KIARVA for non-commercial purposes. Please acknowledge the source as{" "}
+          <strong>KIARVA</strong>, include a link to{" "}
+          <a
+            href="https://kiarva.scilifelab.se"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-primary underline focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 rounded"
+            aria-label="KIARVA website (opens in new tab)"
+          >
+            https://kiarva.scilifelab.se
+          </a>
+          , and optionally cite the RRID as described above.
+        </p>
+        <Title level={2} aria-label="License information section">
+          License Information
+        </Title>
+        <Title level={3} aria-label="Website content license">
+          Website
+        </Title>
+        <p>
+          Unless otherwise stated, this website is licensed under the{" "}
+          <a
+            href="https://creativecommons.org/licenses/by-nc/4.0/"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-primary underline focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 rounded"
+            aria-label="Creative Commons Attribution-NonCommercial 4.0 International License (opens in new tab)"
+          >
+            Creative Commons Attribution-NonCommercial 4.0 International License (CC BY NC 4.0)
+          </a>
+          . This is a human-readable summary of (and not a substitute for){" "}
+          <a
+            href="https://creativecommons.org/licenses/by-nc/4.0/legalcode"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-primary underline focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 rounded"
+            aria-label="Full CC BY NC 4.0 license text (opens in new tab)"
+          >
+            the license.
+          </a>
+        </p>
+        <Title level={4}>You are free to</Title>
+        <ul
+          className="list-disc pl-4"
+          role="list"
+          aria-label="License freedoms"
+        >
+          <li role="listitem">
+            <strong>Share</strong> – copy and redistribute the material in any medium or format for academic purposes
+          </li>
+          <li role="listitem">
+            <strong>Adapt</strong> – remix, transform, and build upon the material for academic purposes
+          </li>
+        </ul>
+        <p>
+            The data content should not be used for commercial purposes.<br/><br/>
+            These freedoms cannot be revoked as long as you follow the license
+            terms.
+        </p>
+        <Title level={4}>Under the following terms</Title>
+        <ul
+          className="list-disc pl-4"
+          role="list"
+          aria-label="License requirements"
+        >
+          <li role="listitem">
+            <strong>Attribution</strong> – You must give appropriate credit,
+            provide a link to the license, and indicate if changes were made.
+          </li>
+          <li role="listitem">
+            <strong>No additional restrictions</strong> – You may not apply
+            legal terms or technological measures that restrict others from
+            doing anything the license permits.
+          </li>
+        </ul>
+        <Title level={4}>Notices</Title>
+        <p>
+          You do not have to comply with the license for elements of the
+          material in the public domain or where your use is permitted by an
+          applicable exception or limitation.
+        </p>
+        <p>
+          No warranties are given. The license may not give you all of the
+          permissions necessary for your intended use. For example, other rights
+          such as publicity, privacy, or moral rights may limit how you use the
+          material.
+        </p>
+        <Title level={3} aria-label="Software license information">
+          Software
+        </Title>
+        <p>
+          Except where otherwise noted, any software in this repository are made
+          available under the{" "}
+          <a
+            href="https://opensource.org/"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-primary underline focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 rounded"
+            aria-label="Open Source Initiative website (opens in new tab)"
+          >
+            OSI
+          </a>
+          -approved{" "}
+          <a
+            href="https://opensource.org/licenses/mit-license.html"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-primary underline focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 rounded"
+            aria-label="MIT License (opens in new tab)"
+          >
+            MIT License
+          </a>
+          .<br />
+          For the rest of the code, © 2025 SciLifeLab Data Centre.
+        </p>
+        <Title level={4}>MIT License</Title>
+        <p role="doc-notice">
+          Permission is hereby granted, free of charge, to any person obtaining
+          a copy of this software and associated documentation files (the
+          &quot;Software&quot;), to deal in the Software without restriction,
+          including without limitation the rights to use, copy, modify, merge,
+          publish, distribute, sublicense, and/or sell copies of the Software,
+          and to permit persons to whom the Software is furnished to do so,
+          subject to the following conditions:
+        </p>
+        <p role="doc-notice">
+          The above copyright notice and this permission notice shall be
+          included in all copies or substantial portions of the Software.
+        </p>
+        <p role="doc-notice">
+          THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY
+          KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+          OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+          NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+          LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+          OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+          WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+        </p>
+      </div>
+      <div className="mt-8">
+        <LastUpdated date="30-01-2026" />
+      </div>
+    </div>
+  );
+}

--- a/next-app/src/app/citation-and-license/page.tsx
+++ b/next-app/src/app/citation-and-license/page.tsx
@@ -91,7 +91,8 @@ export default function CitationAndLicensePage(): ReactElement {
         </Title>
         <p>
           Journalists are welcome to reuse text, images, and other content from
-          KIARVA for non-commercial purposes. Please acknowledge the source as{" "}
+          KIARVA in articles, blog posts, and social media for non-commercial purposes. 
+          Please acknowledge the source as{" "}
           <strong>KIARVA</strong>, include a link to{" "}
           <a
             href="https://kiarva.scilifelab.se"

--- a/next-app/src/app/citation-and-license/page.tsx
+++ b/next-app/src/app/citation-and-license/page.tsx
@@ -17,7 +17,7 @@ export default function CitationAndLicensePage(): ReactElement {
         <p role="doc-abstract">
           In line with the principles of FAIR and Open Science, we encourage the
           reuse and recognition of material made available on KIARVA for non-commercial purposes. This page 
-          provides guidance on how to cite the portal and outlines the licensing 
+          provides guidance on how to cite the website and outlines the licensing 
           conditions for using its content and code.
         </p>
         <Title level={2} aria-label="Information about citing the website">
@@ -204,7 +204,7 @@ export default function CitationAndLicensePage(): ReactElement {
             MIT License
           </a>
           .<br />
-          For the rest of the code, © 2025 SciLifeLab Data Centre.
+          For the rest of the code, © 2026 SciLifeLab Data Centre.
         </p>
         <Title level={4}>MIT License</Title>
         <p role="doc-notice">
@@ -231,7 +231,7 @@ export default function CitationAndLicensePage(): ReactElement {
         </p>
       </div>
       <div className="mt-8">
-        <LastUpdated date="30-01-2026" />
+        <LastUpdated date="02-02-2026" />
       </div>
     </div>
   );

--- a/next-app/src/app/page.tsx
+++ b/next-app/src/app/page.tsx
@@ -14,7 +14,7 @@ const plotHeroBackground = "images/heroPlotImage.png";
 const alignmentHeroBackground = "images/heroAlignmentImage.png";
 const searchHeroBackground = "images/heroSearchImage.png";
 
-const newsDate = new Date("2025-06-25");
+const newsDate = new Date("2026-02-01");
 
 interface FadeAlertProps {
   children: ReactNode;
@@ -108,24 +108,18 @@ export default function HomePage(): ReactElement {
         <FadeAlert title="News" icon={Rss}>
           <time
             dateTime={newsDate.toISOString()}
-            className="block italic mb-2 text-muted-foreground"
+            className="block italic mb-2"
           >
             {newsDate.toLocaleDateString("en-US", {
               year: "numeric",
               month: "long",
-              day: "numeric",
+              // day: "numeric",
             })}
           </time>
           <p>
-            We are excited to introduce the <b>demo version</b> of our new
-            research tool, designed to provide an early glimpse into the
-            DSN&apos;s first dashboard. This preliminary release includes a few
-            example plots to showcase the tool&apos;s analytical capabilities,
-            while the full functionality is being finalized. In this demo
-            version, users can explore data features but won&apos;t have access
-            to all data or access to download FASTA files at this stage. The
-            complete tool, including all data and download options, will be
-            available once the research team has published their findings.
+            We are happy to release the first public version of our new research tool, KIARVA. 
+            Please visit our introduction and instruction videos and note that you can find 
+            Frequently Asked Questions (FAQs) under “Additional information” in the top menu.
           </p>
         </FadeAlert>
       </section>

--- a/next-app/src/app/publications/page.tsx
+++ b/next-app/src/app/publications/page.tsx
@@ -48,7 +48,7 @@ export default function PublicationsPage(): ReactElement {
               linkUrl=""
               title="Ultra-high throughput IGH genotyping of 25 global populations reveals population-biased allelic diversity and homozygous IGHV and IGHD gene deletions"
               authors="Martin Corcoran, Sanjana Narang*, Mateusz Kaduk*, Mark Chernyshev*, Christopher Sundling, Anna Färnert, and Gunilla B. Karlsson Hedestam"
-              journal="Pre-print August 2024"
+              journal="Corcoran et al. Immunity 2026"
               bgColor="bg-neutral"
             />
           </li>

--- a/next-app/src/app/publications/page.tsx
+++ b/next-app/src/app/publications/page.tsx
@@ -47,7 +47,7 @@ export default function PublicationsPage(): ReactElement {
             <PublicationComponent
               linkUrl=""
               title="Ultra-high throughput IGH genotyping of 25 global populations reveals population-biased allelic diversity and homozygous IGHV and IGHD gene deletions"
-              authors="Martin Corcoran, Sanjana Narang*, Mateusz Kaduk*, Mark Chernyshev*, Christopher Sundling, Anna Färnert, and Gunilla B. Karlsson Hedestam"
+              authors="Martin Corcoran, Sanjana Narang, Mateusz Kaduk, Mark Chernyshev, Anna Färnert, Christopher Sundling and Gunilla B. Karlsson Hedestam"
               journal="Corcoran et al. Immunity 2026"
               bgColor="bg-neutral"
             />

--- a/next-app/src/components/FooterComponent.tsx
+++ b/next-app/src/components/FooterComponent.tsx
@@ -18,7 +18,7 @@ const projectLinks: FooterLink[] = [
   { label: "FAQ", href: "/faq" },
 ];
 
-const externalLinks: Array<FooterLink & { external?: boolean }> = [
+const policyLinks: Array<FooterLink & { external?: boolean }> = [
   {
     label: "Privacy policy",
     href: "https://precision-medicine-portal.scilifelab.se/privacy",
@@ -27,7 +27,6 @@ const externalLinks: Array<FooterLink & { external?: boolean }> = [
   {
     label: "Citation and license",
     href: "/citation-and-license",
-    external: true,
   },
 ];
 
@@ -91,7 +90,7 @@ export default function FooterComponent() {
                 Policies
               </h3>
               <ul className="mt-4 space-y-3">
-                {externalLinks.map((l) => (
+                {policyLinks.map((l) => (
                   <li key={l.href}>
                     <a
                       href={l.href}

--- a/next-app/src/components/FooterComponent.tsx
+++ b/next-app/src/components/FooterComponent.tsx
@@ -35,7 +35,7 @@ function FooterLinkList({
   links,
 }: {
   title: string;
-  links: FooterLink[];
+  links: Array<FooterLink & { external?: boolean }>;
 }) {
   return (
     <div>
@@ -44,14 +44,27 @@ function FooterLinkList({
       </h3>
       <ul className="mt-4 space-y-3">
         {links.map((l) => (
-          <li key={l.href}>
+          l.external ?
+          (<li key={l.href}>
+            <a
+              href={l.href}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-sm text-primary-foreground/80 hover:text-primary-foreground hover:underline underline-offset-4 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-foreground/50 rounded-sm"
+            >
+              {l.label}
+              <span className="sr-only"> (opens in a new tab)</span>
+            </a>
+          </li>)
+          :
+          (<li key={l.href}>
             <Link
               href={l.href}
               className="text-sm text-primary-foreground/80 hover:text-primary-foreground hover:underline underline-offset-4 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-foreground/50 rounded-sm"
             >
               {l.label}
             </Link>
-          </li>
+          </li>)
         ))}
       </ul>
     </div>
@@ -85,26 +98,7 @@ export default function FooterComponent() {
           >
             <FooterLinkList title="Tools" links={toolsLinks} />
             <FooterLinkList title="Project" links={projectLinks} />
-            <div>
-              <h3 className="text-sm font-semibold tracking-wide text-primary-foreground">
-                Policies
-              </h3>
-              <ul className="mt-4 space-y-3">
-                {policyLinks.map((l) => (
-                  <li key={l.href}>
-                    <a
-                      href={l.href}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="text-sm text-primary-foreground/80 hover:text-primary-foreground hover:underline underline-offset-4 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-foreground/50 rounded-sm"
-                    >
-                      {l.label}
-                      <span className="sr-only"> (opens in a new tab)</span>
-                    </a>
-                  </li>
-                ))}
-              </ul>
-            </div>
+            <FooterLinkList title="Policies" links={policyLinks} />
           </nav>
         </div>
 

--- a/next-app/src/components/FooterComponent.tsx
+++ b/next-app/src/components/FooterComponent.tsx
@@ -26,7 +26,7 @@ const externalLinks: Array<FooterLink & { external?: boolean }> = [
   },
   {
     label: "Citation and license",
-    href: "https://precision-medicine-portal.scilifelab.se/citation-and-license",
+    href: "/citation-and-license",
     external: true,
   },
 ];

--- a/next-app/src/components/HeaderComponent.tsx
+++ b/next-app/src/components/HeaderComponent.tsx
@@ -103,7 +103,7 @@ export default function HeaderComponent() {
             id="main-navigation"
             className={`${
               isMenuOpen ? "block" : "hidden"
-            } lg:block mt-4 lg:mt-0`}
+            } lg:block mt-4 px-6 lg:mt-0`}
             aria-label="Main navigation"
           >
             <ul className="flex flex-col lg:flex-row lg:flex-wrap lg:items-center lg:space-x-6 space-y-2 lg:space-y-0 text-lg">

--- a/next-app/src/components/common/last-updated.tsx
+++ b/next-app/src/components/common/last-updated.tsx
@@ -1,0 +1,26 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+export interface LastUpdatedProps extends React.HTMLAttributes<HTMLDivElement> {
+  date?: string;
+}
+
+const LastUpdated = React.forwardRef<HTMLDivElement, LastUpdatedProps>(
+  ({ className, date = "2024-10-09", ...props }, ref) => {
+    return (
+      <div
+        ref={ref}
+        className={cn(
+          "mt-auto py-4 text-center text-sm text-muted-foreground",
+          className
+        )}
+        {...props}
+      >
+        Last updated on {date}
+      </div>
+    );
+  }
+);
+LastUpdated.displayName = "LastUpdated";
+
+export { LastUpdated };

--- a/next-app/src/components/common/title.tsx
+++ b/next-app/src/components/common/title.tsx
@@ -1,0 +1,40 @@
+import React from "react";
+import { cn } from "@/lib/utils";
+
+interface TitleProps {
+  level?: 1 | 2 | 3 | 4;
+  children: React.ReactNode;
+  className?: string;
+  id?: string;
+}
+
+export default function Title({
+  level = 1,
+  children,
+  className,
+  id,
+}: TitleProps) {
+  const baseStyles = "text-left text-black font-semibold";
+
+  const sizeStyles = {
+    1: "text-2xl sm:text-3xl md:text-[40px]",
+    2: "text-xl sm:text-2xl md:text-3xl",
+    3: "text-lg sm:text-xl md:text-2xl",
+    4: "text-base sm:text-lg md:text-xl",
+  };
+
+  const Tag = `h${level}` as keyof JSX.IntrinsicElements;
+
+  return (
+    <Tag
+      id={id}
+      className={cn(
+        baseStyles,
+        sizeStyles[level as keyof typeof sizeStyles],
+        className
+      )}
+    >
+      {children}
+    </Tag>
+  );
+}

--- a/next-app/src/components/ui/header-dropdown.tsx
+++ b/next-app/src/components/ui/header-dropdown.tsx
@@ -26,7 +26,7 @@ export function HeaderDropdown({ links }: HeaderDropdownProps) {
   return (
     <DropdownMenu>
       <DropdownMenuTrigger className="text-lg hover:text-gray-300 transition-colors">
-        More <ChevronDown className="ml-1 h-4 w-4 inline" />
+        Additional information <ChevronDown className="ml-1 h-4 w-4 inline" />
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end">
         {Object.entries(links).map(([key, link]) => (


### PR DESCRIPTION
Mostly included changes or additions to text. Added new, purely text based, citation-and-license page based on the same at the precision-medicine-portal. Also rerouted link to citation-and-license from external precision-medicine-portal page to KIARVAs own instance of that page.