### PR TITLE
feature/756-magnifying-glass-images

### DIFF
--- a/next-app/src/components/NewsCarousel.tsx
+++ b/next-app/src/components/NewsCarousel.tsx
@@ -16,7 +16,8 @@ function DisplayNews(props: {imageName: string, imageAlt: string, children: Reac
       <ModalImage 
         imageSrc={props.imageName} 
         imageAlt={props.imageAlt}
-        imgClassesSmall="max-h-60 max-w-60 pr-4 pb-2" 
+        imgClassesSmall="max-h-60 max-w-60"
+        imgClassesButton="mr-4 mb-2"
       />
       {props.children}
     </article>

--- a/next-app/src/components/ui/modal-image.tsx
+++ b/next-app/src/components/ui/modal-image.tsx
@@ -5,13 +5,30 @@ import {
   DialogTitle,
   DialogTrigger,
 } from "@/components/ui/dialog"
+import { ZoomIn } from "lucide-react"
 
-export default function ModalImage(props: {imageSrc: string, imageAlt: string, imgClassesSmall: string}) {
+export default function ModalImage(props: {imageSrc: string, imageAlt: string, imgClassesSmall: string, imgClassesButton?: string}) {
   return (
     <Dialog>
         <DialogTrigger asChild>
-            <button className="float-left">
+            <button
+              type="button"
+              className={`group relative float-left cursor-zoom-in rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 ${props.imgClassesButton ?? ""}`}
+              aria-label={`Enlarge image: ${props.imageAlt}`}
+            >
                 <img className={props.imgClassesSmall} src={props.imageSrc} alt={props.imageAlt} />
+                <span
+                  className="pointer-events-none absolute bottom-3 right-5 flex items-center justify-center rounded-full bg-black/50 p-1.5 transition-opacity duration-200 group-hover:opacity-0 group-focus-visible:opacity-0"
+                  aria-hidden="true"
+                >
+                  <ZoomIn className="h-4 w-4 text-white" />
+                </span>
+                <span
+                  className="pointer-events-none absolute inset-0 flex items-center justify-center rounded-sm bg-black/0 opacity-0 transition-all duration-200 group-hover:bg-black/30 group-hover:opacity-100 group-focus-visible:bg-black/30 group-focus-visible:opacity-100"
+                  aria-hidden="true"
+                >
+                  <ZoomIn className="h-8 w-8 text-white drop-shadow-md" />
+                </span>
             </button>
         </DialogTrigger>
         <DialogContent className="md:max-h-screen-md md:max-w-screen-md">


### PR DESCRIPTION
## Summary

- Add visual affordance and accessibility improvements to clickable news carousel images in `ModalImage` component
- A persistent magnifying glass icon badge (bottom-right corner) now signals that images are enlargeable, without requiring hover
- On hover/focus, a full semi-transparent overlay with a larger zoom icon reinforces the interaction
- Add proper `aria-label`, `type="button"`, `cursor-zoom-in`, and `focus-visible` ring for WCAG compliance
- Fix overlay bleeding past image bounds by moving spacing from image padding (`pr-4 pb-2`) to button margin (`mr-4 mb-2`)

## Changed files

- `next-app/src/components/ui/modal-image.tsx` -- restructured button with two-layer icon overlay, added `ZoomIn` import, `aria-label`, focus ring, and new optional `imgClassesButton` prop
- `next-app/src/components/NewsCarousel.tsx` -- moved spacing classes from `imgClassesSmall` to `imgClassesButton`