### PR TITLE
other/757-read-more-for-text-index

### DIFF
--- a/next-app/package-lock.json
+++ b/next-app/package-lock.json
@@ -11,6 +11,7 @@
         "@headlessui/react": "^2.1.9",
         "@hookform/resolvers": "^3.9.1",
         "@radix-ui/react-accordion": "^1.2.12",
+        "@radix-ui/react-collapsible": "^1.1.12",
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-dropdown-menu": "^2.1.2",
         "@radix-ui/react-label": "^2.1.8",

--- a/next-app/package.json
+++ b/next-app/package.json
@@ -12,6 +12,7 @@
     "@headlessui/react": "^2.1.9",
     "@hookform/resolvers": "^3.9.1",
     "@radix-ui/react-accordion": "^1.2.12",
+    "@radix-ui/react-collapsible": "^1.1.12",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-dropdown-menu": "^2.1.2",
     "@radix-ui/react-label": "^2.1.8",

--- a/next-app/src/app/page.tsx
+++ b/next-app/src/app/page.tsx
@@ -11,6 +11,7 @@ import {
   AccordionTrigger,
 } from "@/components/ui/accordion";
 import NewsCarousel from "@/components/NewsCarousel";
+import ExpandableText from "@/components/ExpandableText";
 
 function DisplayService(props: {video: string, title: string, url: string}) {
   return (
@@ -60,49 +61,61 @@ export default async function HomePage() {
       >
         <h2 id="welcome-heading" className={H_2}>Welcome to KIARVA</h2>
         <div className="grid grid-cols-1 lg:grid-cols-2 lg:max-w-full items-stretch gap-x-6 gap-y-6 lg:gap-y-0 mb-6 mt-6">
-          <p className="pr-2 lg:pr-8">
-            Variation between individuals and populations within the 
-            genomic loci encoding adaptive immune receptor genes (immunoglobulin 
-            (IG) and T cell receptor (TCR)) involves both structural and allelic 
-            diversity. The first release of the Karolinska Institutet Adaptive 
-            Immune Receptor Gene Variant Atlas &mdash; <b>KIARVA</b> &mdash; hosts validated 
-            germline-encoded IG heavy chain (IGH) alleles identified in 2486 
-            individuals from the 1000 Genomes Project (1KGP) collection.<br /><br />
-
-            We chose to use the 1KGP collection as these are often used by population 
-            geneticists to examine global human genetic variation. The results 
-            provided in <b>KIARVA</b> can therefore be integrated into a larger body of 
-            research involving the same populations and individual donor cases and 
-            provides a means to test, compare and benchmark future genotyping protocols. 
-            As additional alleles are discovered in populations and individuals that 
-            are not represented in the 1KGP set they will be presented as part of 
-            separate publications.<br /><br />
-
-            <b>KIARVA</b> is open source and provides downloadable FASTA files of 561 IGHV, 
-            51 IGHD and 12 IGHJ alleles, as well as information about the frequency 
-            of each IGHV allele in 5 continental superpopulations and 25 subpopulations. 
-            Soon, <b>KIARVA</b> will be extended to also contain population-based information 
-            about IG kappa (IGK), lambda (IGK) and TCR alleles.<br /><br />
-
-            <b>When using this database, please cite Corcoran et al. Immunity 2026.
-            The resource should not be used for commercial purposes.
-            For questions, please contact the authors.
-            </b>
-            <br /><br />
-            For more information about KIARVA, see the pages{" "}
-            <Link href="/methodology" className={textLinkClasses}>
-              Methodology
-            </Link>
-            ,{" "}
-            <Link href="/faq" className={textLinkClasses}>
-              FAQ
-            </Link>{" "}
-            and{" "}
-            <Link href="/about" className={textLinkClasses}>
-              About
-            </Link>
-            .
-          </p>
+          <ExpandableText
+            className="pr-2 lg:pr-8"
+            preview={
+              <>
+                <p>
+                  Variation between individuals and populations within the 
+                  genomic loci encoding adaptive immune receptor genes (immunoglobulin 
+                  (IG) and T cell receptor (TCR)) involves both structural and allelic 
+                  diversity. The first release of the Karolinska Institutet Adaptive 
+                  Immune Receptor Gene Variant Atlas &mdash; <b>KIARVA</b> &mdash; hosts validated 
+                  germline-encoded IG heavy chain (IGH) alleles identified in 2486 
+                  individuals from the 1000 Genomes Project (1KGP) collection.
+                </p>
+                <p className="pt-4">
+                  We chose to use the 1KGP collection as these are often used by population 
+                  geneticists to examine global human genetic variation. The results 
+                  provided in <b>KIARVA</b> can therefore be integrated into a larger body of 
+                  research involving the same populations and individual donor cases and 
+                  provides a means to test, compare and benchmark future genotyping protocols. 
+                  As additional alleles are discovered in populations and individuals that 
+                  are not represented in the 1KGP set they will be presented as part of 
+                  separate publications.
+                </p>
+              </>
+            }
+          >
+            <p className="pt-4">
+              <b>KIARVA</b> is open source and provides downloadable FASTA files of 561 IGHV, 
+              51 IGHD and 12 IGHJ alleles, as well as information about the frequency 
+              of each IGHV allele in 5 continental superpopulations and 25 subpopulations. 
+              Soon, <b>KIARVA</b> will be extended to also contain population-based information 
+              about IG kappa (IGK), lambda (IGK) and TCR alleles.
+            </p>
+            <p className="pt-4">
+              <b>When using this database, please cite Corcoran et al. Immunity 2026.
+              The resource should not be used for commercial purposes.
+              For questions, please contact the authors.
+              </b>
+            </p>
+            <p className="pt-4">
+              For more information about KIARVA, see the pages{" "}
+              <Link href="/methodology" className={textLinkClasses}>
+                Methodology
+              </Link>
+              ,{" "}
+              <Link href="/faq" className={textLinkClasses}>
+                FAQ
+              </Link>{" "}
+              and{" "}
+              <Link href="/about" className={textLinkClasses}>
+                About
+              </Link>
+              .
+            </p>
+          </ExpandableText>
           <VideoIframe className="max-w-full aspect-video w-[36em]" 
             videoId={YouTubeVideos["intro"].address} 
             videoTitle={YouTubeVideos["intro"].title}

--- a/next-app/src/app/page.tsx
+++ b/next-app/src/app/page.tsx
@@ -60,7 +60,7 @@ export default async function HomePage() {
         aria-labelledby="welcome-heading"
       >
         <h2 id="welcome-heading" className={H_2}>Welcome to KIARVA</h2>
-        <div className="grid grid-cols-1 lg:grid-cols-2 lg:max-w-full items-stretch gap-x-6 gap-y-6 lg:gap-y-0 mb-6 mt-6">
+        <div className="grid grid-cols-1 lg:grid-cols-2 lg:max-w-full items-start gap-x-6 gap-y-6 lg:gap-y-0 mb-6 mt-6">
           <ExpandableText
             className="pr-2 lg:pr-8"
             preview={
@@ -116,10 +116,15 @@ export default async function HomePage() {
               .
             </p>
           </ExpandableText>
-          <VideoIframe className="max-w-full aspect-video w-[36em]" 
-            videoId={YouTubeVideos["intro"].address} 
-            videoTitle={YouTubeVideos["intro"].title}
-          />
+          <figure
+            role="group"
+            aria-label={YouTubeVideos["intro"].title}
+          >
+            <VideoIframe className="max-w-full aspect-video w-[36em]" 
+              videoId={YouTubeVideos["intro"].address} 
+              videoTitle={YouTubeVideos["intro"].title}
+            />
+          </figure>
         </div>
       </section>
       <div className="divider pt-4" aria-hidden="true" />

--- a/next-app/src/app/page.tsx
+++ b/next-app/src/app/page.tsx
@@ -13,91 +13,89 @@ import {
 import NewsCarousel from "@/components/NewsCarousel";
 import ExpandableText from "@/components/ExpandableText";
 
-function DisplayService(props: {video: string, title: string, url: string}) {
+function DisplayService(props: { video: string; title: string; url: string }) {
   return (
     <div className="relative w-full rounded-lg border p-4 gap-6 flex flex-col bg-muted">
-      <h3 className="text-xl lg:text-2xl font-bold">
-        {props.title}
-      </h3>
+      <h3 className="text-xl lg:text-2xl font-bold">{props.title}</h3>
       <Accordion
-          type="single"
-          collapsible
-          className="w-full rounded-lg hover:bg-primary/20"
-          role="region"
-        >
+        type="single"
+        collapsible
+        className="w-full rounded-lg hover:bg-primary/20"
+        role="region"
+      >
         <AccordionItem value="item-1">
           <AccordionTrigger className="pl-2">
             Watch example video
           </AccordionTrigger>
           <AccordionContent>
-              <VideoIframe className="w-full aspect-video max-w-[36em] pl-2" 
-                videoId={YouTubeVideos[props.video].address} 
-                videoTitle={YouTubeVideos[props.video].title} 
-              />
+            <VideoIframe
+              className="w-full aspect-video max-w-[36em] pl-2"
+              videoId={YouTubeVideos[props.video].address}
+              videoTitle={YouTubeVideos[props.video].title}
+            />
           </AccordionContent>
         </AccordionItem>
       </Accordion>
-      <Button
-        variant="default"
-        size="default"
-        className="w-1/3"
-        asChild
-        >
+      <Button variant="default" size="default" className="w-1/3" asChild>
         <Link href={"/" + props.url}>Go to page</Link>
       </Button>
     </div>
-  )
+  );
 }
 
 export default async function HomePage() {
-  const textLinkClasses: string = "font-medium text-fg-brand hover:underline";
+  const textLinkClasses: string = "font-medium text-primary hover:underline";
   return (
     <main className="bg-base-100 space-y-4 lg:space-y-6 p-4 lg:px-12 lg:pb-18 xl:px-24 xl:pb-28 2xl:max-w-screen-2xl 2xl:mx-auto">
       <h1 className="sr-only">
         KIARVA - Adaptive Immune Receptor Gene Variant Atlas
       </h1>
-      <section
-        aria-labelledby="welcome-heading"
-      >
-        <h2 id="welcome-heading" className={H_2}>Welcome to KIARVA</h2>
+      <section aria-labelledby="welcome-heading">
+        <h2 id="welcome-heading" className={H_2}>
+          Welcome to KIARVA
+        </h2>
         <div className="grid grid-cols-1 lg:grid-cols-2 lg:max-w-full items-start gap-x-6 gap-y-6 lg:gap-y-0 mb-6 mt-6">
-          <ExpandableText
-            className="pr-2 lg:pr-8"
-            preview={
-              <>
+          <div className="pr-2 lg:pr-8">
+            <ExpandableText
+              preview={
                 <p>
-                  Variation between individuals and populations within the 
-                  genomic loci encoding adaptive immune receptor genes (immunoglobulin 
-                  (IG) and T cell receptor (TCR)) involves both structural and allelic 
-                  diversity. The first release of the Karolinska Institutet Adaptive 
-                  Immune Receptor Gene Variant Atlas &mdash; <b>KIARVA</b> &mdash; hosts validated 
-                  germline-encoded IG heavy chain (IGH) alleles identified in 2486 
-                  individuals from the 1000 Genomes Project (1KGP) collection.
+                  Variation between individuals and populations within the
+                  genomic loci encoding adaptive immune receptor genes
+                  (immunoglobulin (IG) and T cell receptor (TCR)) involves both
+                  structural and allelic diversity. The first release of the
+                  Karolinska Institutet Adaptive Immune Receptor Gene Variant
+                  Atlas &mdash; <b>KIARVA</b> &mdash; hosts validated
+                  germline-encoded IG heavy chain (IGH) alleles identified in
+                  2486 individuals from the 1000 Genomes Project (1KGP)
+                  collection.
                 </p>
-                <p className="pt-4">
-                  We chose to use the 1KGP collection as these are often used by population 
-                  geneticists to examine global human genetic variation. The results 
-                  provided in <b>KIARVA</b> can therefore be integrated into a larger body of 
-                  research involving the same populations and individual donor cases and 
-                  provides a means to test, compare and benchmark future genotyping protocols. 
-                  As additional alleles are discovered in populations and individuals that 
-                  are not represented in the 1KGP set they will be presented as part of 
-                  separate publications.
-                </p>
-              </>
-            }
-          >
+              }
+            >
+              <p className="pt-4">
+                We chose to use the 1KGP collection as these are often used by
+                population geneticists to examine global human genetic variation.
+                The results provided in <b>KIARVA</b> can therefore be integrated
+                into a larger body of research involving the same populations and
+                individual donor cases and provides a means to test, compare and
+                benchmark future genotyping protocols. As additional alleles are
+                discovered in populations and individuals that are not represented
+                in the 1KGP set they will be presented as part of separate
+                publications.
+              </p>
+              <p className="pt-4">
+                <b>KIARVA</b> is open source and provides downloadable FASTA files
+                of 561 IGHV, 51 IGHD and 12 IGHJ alleles, as well as information
+                about the frequency of each IGHV allele in 5 continental
+                superpopulations and 25 subpopulations. Soon, <b>KIARVA</b> will
+                be extended to also contain population-based information about IG
+                kappa (IGK), lambda (IGK) and TCR alleles.
+              </p>
+            </ExpandableText>
             <p className="pt-4">
-              <b>KIARVA</b> is open source and provides downloadable FASTA files of 561 IGHV, 
-              51 IGHD and 12 IGHJ alleles, as well as information about the frequency 
-              of each IGHV allele in 5 continental superpopulations and 25 subpopulations. 
-              Soon, <b>KIARVA</b> will be extended to also contain population-based information 
-              about IG kappa (IGK), lambda (IGK) and TCR alleles.
-            </p>
-            <p className="pt-4">
-              <b>When using this database, please cite Corcoran et al. Immunity 2026.
-              The resource should not be used for commercial purposes.
-              For questions, please contact the authors.
+              <b>
+                When using this database, please cite Corcoran et al. Immunity
+                2026. The resource should not be used for commercial purposes.
+                For questions, please contact the authors.
               </b>
             </p>
             <p className="pt-4">
@@ -115,37 +113,49 @@ export default async function HomePage() {
               </Link>
               .
             </p>
-          </ExpandableText>
-          <figure
-            role="group"
-            aria-label={YouTubeVideos["intro"].title}
-          >
-            <VideoIframe className="max-w-full aspect-video w-[36em]" 
-              videoId={YouTubeVideos["intro"].address} 
+          </div>
+          <figure role="group" aria-label={YouTubeVideos["intro"].title}>
+            <VideoIframe
+              className="max-w-full aspect-video w-[36em]"
+              videoId={YouTubeVideos["intro"].address}
               videoTitle={YouTubeVideos["intro"].title}
             />
           </figure>
         </div>
       </section>
       <div className="divider pt-4" aria-hidden="true" />
-      <section
-        aria-labelledby="news-heading"
-      >
-        <h2 id="news-heading" className={H_2}>News</h2>
-          <NewsCarousel />
+      <section aria-labelledby="news-heading">
+        <h2 id="news-heading" className={H_2}>
+          News
+        </h2>
+        <NewsCarousel />
       </section>
       <div className="divider pt-4" aria-hidden="true" />
-      <section
-        aria-labelledby="features-heading"
-      >
+      <section aria-labelledby="features-heading">
         <h2 id="features-heading" className={H_2}>
           Resources
         </h2>
         <div className="grid grid-cols-1 lg:grid-cols-2 lg:max-w-full items-stretch gap-6 mb-6 mt-6">
-          <DisplayService video="download" title="Download FASTA files" url="download" />
-          <DisplayService video="frequencies" title="View population frequencies" url="plot" />
-          <DisplayService video="alignments" title="View sequence alignments" url="msa" />
-          <DisplayService video="search" title="Search for sequences" url="sequencesearch" />
+          <DisplayService
+            video="download"
+            title="Download FASTA files"
+            url="download"
+          />
+          <DisplayService
+            video="frequencies"
+            title="View population frequencies"
+            url="plot"
+          />
+          <DisplayService
+            video="alignments"
+            title="View sequence alignments"
+            url="msa"
+          />
+          <DisplayService
+            video="search"
+            title="Search for sequences"
+            url="sequencesearch"
+          />
         </div>
       </section>
     </main>

--- a/next-app/src/components/ExpandableText.tsx
+++ b/next-app/src/components/ExpandableText.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import * as React from "react";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible";
+import { ChevronDown } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+interface ExpandableTextProps {
+  preview: React.ReactNode;
+  children: React.ReactNode;
+  labelExpand?: string;
+  labelCollapse?: string;
+  className?: string;
+}
+
+export default function ExpandableText({
+  preview,
+  children,
+  labelExpand = "Read more",
+  labelCollapse = "Show less",
+  className,
+}: ExpandableTextProps) {
+  const [open, setOpen] = React.useState(false);
+  const containerRef = React.useRef<HTMLDivElement>(null);
+
+  const handleOpenChange = (nextOpen: boolean) => {
+    setOpen(nextOpen);
+    if (!nextOpen && containerRef.current) {
+      const rect = containerRef.current.getBoundingClientRect();
+      if (rect.top < 0) {
+        containerRef.current.scrollIntoView({
+          behavior: "smooth",
+          block: "nearest",
+        });
+      }
+    }
+  };
+
+  return (
+    <Collapsible
+      open={open}
+      onOpenChange={handleOpenChange}
+      className={className}
+    >
+      <div ref={containerRef}>{preview}</div>
+      <CollapsibleContent className="overflow-hidden data-[state=open]:animate-collapsible-down data-[state=closed]:animate-collapsible-up">
+        {children}
+      </CollapsibleContent>
+      <CollapsibleTrigger
+        className={cn(
+          "inline-flex items-center gap-1 font-medium text-fg-brand hover:underline",
+          "cursor-pointer text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+          "mt-1"
+        )}
+      >
+        {open ? labelCollapse : labelExpand}
+        <ChevronDown
+          className={cn(
+            "h-4 w-4 shrink-0 transition-transform duration-200",
+            open && "rotate-180"
+          )}
+          aria-hidden="true"
+        />
+      </CollapsibleTrigger>
+    </Collapsible>
+  );
+}

--- a/next-app/src/components/ExpandableText.tsx
+++ b/next-app/src/components/ExpandableText.tsx
@@ -52,16 +52,16 @@ export default function ExpandableText({
       </CollapsibleContent>
       <CollapsibleTrigger
         className={cn(
-          "inline-flex items-center gap-1 font-medium text-fg-brand hover:underline",
-          "cursor-pointer text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
-          "mt-1"
+          "inline-flex items-center gap-1 font-medium text-primary hover:underline",
+          "cursor-pointer text-base focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+          "mt-1",
         )}
       >
         {open ? labelCollapse : labelExpand}
         <ChevronDown
           className={cn(
             "h-4 w-4 shrink-0 transition-transform duration-200",
-            open && "rotate-180"
+            open && "rotate-180",
           )}
           aria-hidden="true"
         />

--- a/next-app/src/components/NewsCarousel.tsx
+++ b/next-app/src/components/NewsCarousel.tsx
@@ -7,6 +7,7 @@ import {
 } from "@/components/ui/carousel"
 import ModalImage from "@/components/ui/modal-image";
 import { Articles } from "@/content/NewsArticles";
+import ExpandableText from "@/components/ExpandableText";
 
 
 
@@ -53,14 +54,20 @@ export default function NewsCarousel() {
                       })
                     }
                   </time>
-                  <p className="max-w-full pr-2 lg:pr-8 pb-2">
-                    {article.textBody.map((paragraph, index) => (
-                      (<p key={index}>
-                        {paragraph}
-                        <br/><br/>
-                      </p>)
-                    ))}
-                  </p>
+                  {article.textBody.length > 1 ? (
+                    <ExpandableText
+                      className="max-w-full pr-2 lg:pr-8 pb-2"
+                      preview={<p>{article.textBody[0]}</p>}
+                    >
+                      {article.textBody.slice(1).map((paragraph, pIdx) => (
+                        <p key={pIdx} className="pt-4">{paragraph}</p>
+                      ))}
+                    </ExpandableText>
+                  ) : (
+                    <div className="max-w-full pr-2 lg:pr-8 pb-2">
+                      <p>{article.textBody[0]}</p>
+                    </div>
+                  )}
                 </div>
               </DisplayNews>
             </CarouselItem>

--- a/next-app/src/components/YoutubeIframe.tsx
+++ b/next-app/src/components/YoutubeIframe.tsx
@@ -13,6 +13,7 @@ const VideoIframe: React.FC<IProps> = (props) => {
       title={videoTitle}
       className={className}
       src={videoURL}
+      loading="lazy"
       allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
       allowFullScreen
     />

--- a/next-app/src/components/ui/collapsible.tsx
+++ b/next-app/src/components/ui/collapsible.tsx
@@ -1,0 +1,11 @@
+"use client"
+
+import * as CollapsiblePrimitive from "@radix-ui/react-collapsible"
+
+const Collapsible = CollapsiblePrimitive.Root
+
+const CollapsibleTrigger = CollapsiblePrimitive.CollapsibleTrigger
+
+const CollapsibleContent = CollapsiblePrimitive.CollapsibleContent
+
+export { Collapsible, CollapsibleTrigger, CollapsibleContent }

--- a/next-app/src/content/NewsArticles.ts
+++ b/next-app/src/content/NewsArticles.ts
@@ -1,10 +1,10 @@
 type Article = Readonly<{
-    imageName: string,
-    imageAlt: string,
-    date: string,
-    showDay: boolean,
-    textBody: string[],
-}>
+  imageName: string;
+  imageAlt: string;
+  date: string;
+  showDay: boolean;
+  textBody: string[];
+}>;
 
 /* 
 A list of article objects. How to use it:
@@ -45,32 +45,29 @@ Add the following article:
 For a longer explanation on how it works, see bottom of the page.
 */
 
-
 export const Articles: Article[] = [
-    {
-        imageName: "KIARVANewsThumbnail2.jpeg",
-        imageAlt: "KIARVA news thumbnail",
-        date:"2026-03-01",
-        showDay: false,
-        textBody:
-        [
-            `
+  {
+    imageName: "KIARVANewsThumbnail2.jpeg",
+    imageAlt: "KIARVA news thumbnail",
+    date: "2026-03-01",
+    showDay: false,
+    textBody: [
+      `
                 We are happy to release the first public version of our new \
                 research tool, KIARVA, described in detail in Corcoran et al. \
                 Immunity 2026. Please visit our introduction and instruction \
                 videos and note that you can find Frequently Asked Questions \
                 (FAQs) under “Additional information” in the top menu.
             `,
-        ]
-    },
-    {
-        imageName: "CorcoranEtAlImmunity2026.jpg",
-        imageAlt: "Corcoran et al. Immunity 2026 visual abstract",
-        date:"2026-03-04",
-        showDay: true,
-        textBody: 
-        [
-            `
+    ],
+  },
+  {
+    imageName: "CorcoranEtAlImmunity2026.jpg",
+    imageAlt: "Corcoran et al. Immunity 2026 visual abstract",
+    date: "2026-03-04",
+    showDay: true,
+    textBody: [
+      `
                 The genes of the immunoglobulin heavy chain (IGH) locus are \
                 critical for the formation of antibodies. Previous studies using \
                 limited numbers of individuals have indicated that IG germline \
@@ -78,8 +75,10 @@ export const Articles: Article[] = [
                 present a novel method for high-throughput sequencing of the \
                 functional adaptive immune genes located in complex genomic \
                 regions, and we utilize this technique to genotype 2486 individuals \
-                from the 1KGP population set, comprising 25 sub-populations. The \
-                study reveals high allelic coding variation and frequent genomic \
+                from the 1KGP population set, comprising 25 sub-populations.
+                            `,
+      `
+                The study reveals high allelic coding variation and frequent genomic \
                 structural variation, including gene deletions and duplications \
                 that vary in frequency between the global population groups, indicative \
                 of local adaptation in response to endemic and pandemic associated \
@@ -89,7 +88,7 @@ export const Articles: Article[] = [
                 common ancestor of humans and archaic hominins, approximately 600,000 \
                 before the present. 
             `,
-            `
+      `
                 The most surprising finding was the frequency of a structural deletion \
                 resulting in the loss of 6 contiguous genes within the diversity (D) gene \
                 locus that was present in all populations, but with especially high \
@@ -100,7 +99,7 @@ export const Articles: Article[] = [
                 deletion suggests population level differences in antibody responses that \
                 merit further investigation. 
             `,
-            `
+      `
                 The study resulted in the identification of over three hundred additional \
                 gene variants in the global population, facilitating future identification \
                 of functional differences associated with localized immune gene adaptation \
@@ -108,26 +107,24 @@ export const Articles: Article[] = [
                 an important new methodology for analysis of complex immune genes and \
                 provides a comprehensive resource for ongoing study of the human immune \
                 system at an individual and population level.
-            `
-        ]
-
-    },
-    {
-        imageName: "GAFischerCorcoranImmunity2026.jpg",
-        imageAlt: "GA Fischer, Corcoran Immunity 2026 visual abstract",
-        date:"2026-03-04",
-        showDay: true,
-        textBody:
-        [
-            `
+            `,
+    ],
+  },
+  {
+    imageName: "GAFischerCorcoranImmunity2026.jpg",
+    imageAlt: "GA Fischer, Corcoran Immunity 2026 visual abstract",
+    date: "2026-03-04",
+    showDay: true,
+    textBody: [
+      `
                 In Fischer, Corcoran, et al., we investigated how inherited variation \
                 in antibody genes influences antibody responses to influenza HA to \
                 highlight population vulnerabilities that could be mitigated in the \
                 design of globally protective vaccines.
             `,
-        ]
-    },
-]
+    ],
+  },
+];
 
 /*
 How it works:

--- a/next-app/tailwind.config.ts
+++ b/next-app/tailwind.config.ts
@@ -108,10 +108,28 @@ export default {
             height: "0",
           },
         },
+        "collapsible-down": {
+          from: {
+            height: "0",
+          },
+          to: {
+            height: "var(--radix-collapsible-content-height)",
+          },
+        },
+        "collapsible-up": {
+          from: {
+            height: "var(--radix-collapsible-content-height)",
+          },
+          to: {
+            height: "0",
+          },
+        },
       },
       animation: {
         "accordion-down": "accordion-down 0.2s ease-out",
         "accordion-up": "accordion-up 0.2s ease-out",
+        "collapsible-down": "collapsible-down 0.2s ease-out",
+        "collapsible-up": "collapsible-up 0.2s ease-out",
       },
     },
   },


### PR DESCRIPTION
## Add "Read more / Show less" expandable text to index page

### Summary

- Introduce a reusable `ExpandableText` client component built on Radix Collapsible (via shadcn) that truncates long text sections and lets users expand them on demand.
- Apply it to the Welcome section in `page.tsx` (first two paragraphs visible, rest expandable) and to multi-paragraph news articles in `NewsCarousel.tsx`.
- Fix invalid nested `<p>` elements in `NewsCarousel.tsx` that existed previously.

### Changes

| File | What changed |
|---|---|
| `src/components/ExpandableText.tsx` | New client component: accepts `preview` (always visible) and `children` (collapsible), with animated expand/collapse and scroll-into-view on collapse |
| `src/components/ui/collapsible.tsx` | Auto-generated shadcn wrapper for `@radix-ui/react-collapsible` |
| `src/app/page.tsx` | Welcome text split into preview (2 paragraphs) + expandable (3 paragraphs) using `ExpandableText` |
| `src/components/NewsCarousel.tsx` | Multi-paragraph articles wrapped in `ExpandableText`; single-paragraph articles render as before. Fixed nested `<p>` tags |
| `tailwind.config.ts` | Added `collapsible-down` / `collapsible-up` keyframe animations |
| `package.json` | Added `@radix-ui/react-collapsible` dependency |