### PR TITLE
feature/768: Update Changelog

### DIFF
--- a/next-app/package-lock.json
+++ b/next-app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kiarva-frontend",
-  "version": "0.10.5",
+  "version": "1.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kiarva-frontend",
-      "version": "0.10.5",
+      "version": "1.1.1",
       "dependencies": {
         "@headlessui/react": "^2.1.9",
         "@hookform/resolvers": "^3.9.1",

--- a/next-app/src/app/changelog/page.tsx
+++ b/next-app/src/app/changelog/page.tsx
@@ -26,8 +26,7 @@ export default function ChangeLogPage(): ReactElement {
 
     for (let i = 0; i < changeLogHistory.length; i++) {
       if (changeLogHistory[i].version < compareToVersion) {
-          const updateLength = changeLogHistory[i][updateTypeKey].length;
-          for (let j = 0; j < updateLength; j++) {
+          for (let j = 0; j < changeLogHistory[i][updateTypeKey].length; j++) {
             if (changeLogHistory[i][updateTypeKey][j]) {
               return changeLogHistory[i].version;
             }

--- a/next-app/src/app/changelog/page.tsx
+++ b/next-app/src/app/changelog/page.tsx
@@ -22,10 +22,9 @@ export default function ChangeLogPage(): ReactElement {
   // This is then used on the website to display "No updates. Last updated in version 1.2.1." for version
   // 1.2.9.
   function findLatestUpdate(updateType: updateTypeEnum, compareToVersion: string): string {
-    const changeLogHistoryLength = changeLogHistory.length;
     const updateTypeKey = updateType as keyof typeof changeLogHistory[number];
 
-    for (let i = 0; i < changeLogHistoryLength; i++) {
+    for (let i = 0; i < changeLogHistory.length; i++) {
       if (changeLogHistory[i].version < compareToVersion) {
           const updateLength = changeLogHistory[i][updateTypeKey].length;
           for (let j = 0; j < updateLength; j++) {

--- a/next-app/src/app/changelog/page.tsx
+++ b/next-app/src/app/changelog/page.tsx
@@ -2,12 +2,43 @@
 
 "use client";
 
-import { ReactElement } from "react";
-import { BODY_CLASSES, H_1, currentVersion } from "@/constants";
+import { ReactElement} from "react";
+import { BODY_CLASSES, H_1 } from "@/constants";
 import ChangeLogComponent from "@/components/ChangeLogComponent";
+import { changeLogCurrent, changeLogHistory } from "@/content/ChangeLog";
 
 export default function ChangeLogPage(): ReactElement {
   const pageTitle: string = "Change log";
+
+  enum updateTypeEnum {
+    databaseUpdate = "databaseUpdates",
+    designAndBugfixesUpdate = "designAndBugFixes",
+  }
+
+  // Function that looks at a given update type (of either database or design and bugfixes), goes 
+  // through the change log history and finds the most recent version where anything was updated for that type.
+  // For example, if the changelog had database changes in version 1.2.1 and no changes after that, and the current
+  // version is 1.2.9, then the function will return "1.2.1".
+  // This is then used on the website to display "No updates. Last updated in version 1.2.1." for version
+  // 1.2.9.
+  function findLatestUpdate(updateType: updateTypeEnum, compareToVersion: string): string {
+    const changeLogHistoryLength = changeLogHistory.length;
+    const updateTypeKey = updateType as keyof typeof changeLogHistory[number];
+
+    for (let i = 0; i < changeLogHistoryLength; i++) {
+      if (changeLogHistory[i].version < compareToVersion) {
+          const updateLength = changeLogHistory[i][updateTypeKey].length;
+          for (let j = 0; j < updateLength; j++) {
+            if (changeLogHistory[i][updateTypeKey][j]) {
+              return changeLogHistory[i].version;
+            }
+          }
+      }
+    }
+    // Should in practice not be reached as long as ChangeLog.ts is not empty.
+    // Needed so that return type can be string instead of string | null.
+    return "N/A"
+  }
 
   return (
     <main className={BODY_CLASSES}>
@@ -32,13 +63,14 @@ export default function ChangeLogPage(): ReactElement {
           The change log provides a comprehensive overview of all releases of
           the KI Adaptive Immune Receptor Gene Variant Atlas. Each
           version&apos;s card features two buttons: &apos;Frontend
-          Repository&apos; and &apos;Backend Repository&apos;. Clicking a button
-          on the current version card will direct you to the respective GitHub
-          repository. For previous versions, clicking a button will take you to
-          the relevant GitHub pull request. In the near future, we will include
-          instructions in the README file on how to run the selected version
-          locally. The links to the Github repositiories are not functional
-          until the publication of the data.
+          Repository&apos; and &apos;Backend Repository&apos;. Clicking these buttons
+          will direct you to the relevant release for that version.
+          <br/><br/>
+          The version number works in the following way:
+          Increments of the first integer represents major data changes. Increments of 
+          the second integer indicates smaller fixes related to the data or how it 
+          is processed. Increments of the third integer indicates minor bug fixes or UI 
+          changes on the website.
         </p>
       </aside>
 
@@ -48,68 +80,65 @@ export default function ChangeLogPage(): ReactElement {
         </h2>
         <article className="pt-2 pb-4">
           <ChangeLogComponent
-            title={`Version ${currentVersion}`}
-            databaseUpdates={[
-              "Initial release containing IGH data.",
-            ]}
-            designAndBugFixes={["Initial release"]}
+            title={`Version ${changeLogCurrent.version}`}
+            databaseUpdates={
+                  (changeLogCurrent.databaseUpdates.length >0) ?
+                    changeLogCurrent.databaseUpdates.map((dbUpdate) =>
+                      dbUpdate
+                    )
+                    :
+                    `No updates. Last updated in version ${findLatestUpdate(updateTypeEnum.databaseUpdate, changeLogCurrent.version)}.`
+                }
+            designAndBugFixes={
+                  (changeLogCurrent.designAndBugFixes.length >0) ?
+                    changeLogCurrent.designAndBugFixes.map((designAndFixesUpdate) =>
+                      designAndFixesUpdate
+                    )
+                    :
+                    `No updates. Last updated in version ${findLatestUpdate(updateTypeEnum.designAndBugfixesUpdate, changeLogCurrent.version)}.`
+                }
             isCurrent={true}
-            frontEndLink="https://github.com/ScilifelabDataCentre/kiarva-frontend"
-            backEndLink="https://github.com/ScilifelabDataCentre/kiarva-backend"
+            frontEndLink="https://github.com/ScilifelabDataCentre/kiarva-frontend/releases/latest"
+            frontEndTag={changeLogCurrent.frontendReleaseTag}
+            backEndLink="https://github.com/ScilifelabDataCentre/kiarva-backend/releases/latest"
+            backEndTag={changeLogCurrent.backendReleaseTag}
           />
         </article>
       </section>
-      {/*}
       <section aria-labelledby="previous-versions-heading">
         <h2 id="previous-versions-heading" className="divider pt-4">Previous versions</h2>
         <div className="pt-2 pb-4">
-          <article>
-            <ChangeLogComponent
-              title="Version 0.1.0"
-              databaseUpdates={[
-                "TBD",
-              ]}
-              designAndBugFixes={[
-                "Initial release",
-              ]}
-              isCurrent={false}
-              frontEndLink="https://github.com/ScilifelabDataCentre/immunediscover-service-frontend"
-              backEndLink="https://github.com/ScilifelabDataCentre/immunediscover-service-backend"
-            />
-          </article>
-          <article>
-            <ChangeLogComponent
-              title="Version 0.0.0"
-              databaseUpdates={[
-                "TBD",
-              ]}
-              designAndBugFixes={[
-                "TBD",
-              ]}
-              isCurrent={false}
-              frontEndLink="https://github.com/ScilifelabDataCentre/kiarva-frontend"
-              backEndLink="https://github.com/ScilifelabDataCentre/kiarva-backend"
-            />
-          </article>
+          {changeLogHistory.map((item, index) => 
+            <article key={index}>
+              <ChangeLogComponent
+                title={`Version ${item.version}`}
+                databaseUpdates={
+                  (item.databaseUpdates.length >0) ?
+                    item.databaseUpdates.map((dbUpdate) =>
+                      dbUpdate
+                    )
+                    :
+                    `No updates. Last updated in version ${findLatestUpdate(updateTypeEnum.databaseUpdate, item.version)}.`
+                }
+                designAndBugFixes={
+                  (item.designAndBugFixes.length >0) ?
+                    item.designAndBugFixes.map((designAndFixesUpdate) =>
+                      designAndFixesUpdate
+                    )
+                    :
+                    `No updates. Last updated in version ${findLatestUpdate(updateTypeEnum.designAndBugfixesUpdate, item.version)}.`
+                }
+                isCurrent={false}
+                frontEndLink={`https://github.com/ScilifelabDataCentre/kiarva-frontend/releases/tag/v${item.frontendReleaseTag}`}
+                frontEndTag={`v${item.frontendReleaseTag}`}
+                backEndLink={`https://github.com/ScilifelabDataCentre/kiarva-backend/releases/tag/v${item.backendReleaseTag}`}
+                backEndTag={`v${item.backendReleaseTag}`}
+              />
+            </article>          
+            )
+          }
         </div>
       </section>
-      <section>
-        <article>
-          <ChangeLogComponent
-            title="Version 0.0.0"
-            databaseUpdates={[
-              "TBD",
-            ]}
-            designAndBugFixes={[
-              "TBD",
-            ]}
-            isCurrent={false}
-            frontEndLink="https://github.com/ScilifelabDataCentre/kiarva-frontend"
-            backEndLink="https://github.com/ScilifelabDataCentre/kiarva-backend"
-          />
-        </article>
-      </section>
-      */}
     </main>
   );
 }

--- a/next-app/src/components/ChangeLogComponent.tsx
+++ b/next-app/src/components/ChangeLogComponent.tsx
@@ -94,7 +94,7 @@ const ChangeLogComponent: React.FC<ChangeLogComponentProps> = ({
             Database Updates
           </h4>
           <ul className="text-sm lg:text-base">
-            {updatesDatabaseUpdatesArray.length > 5 ?
+            {updatesDatabaseUpdatesArray.length > 10 ?
               (<ExpandableText preview={
                 updatesDatabaseUpdatesArray.slice(0, 10).map((update, index) => (
                   <li key={index}>• {update}</li>
@@ -122,7 +122,7 @@ const ChangeLogComponent: React.FC<ChangeLogComponentProps> = ({
             Design & Bug Fixes
           </h4>
           <ul className="text-sm lg:text-base">
-            {updatesDesignAndBugFixesArray.length > 5 ?
+            {updatesDesignAndBugFixesArray.length > 10 ?
               (<ExpandableText preview={
                 updatesDesignAndBugFixesArray.slice(0, 10).map((update, index) => (
                   <li key={index}>• {update}</li>

--- a/next-app/src/components/ChangeLogComponent.tsx
+++ b/next-app/src/components/ChangeLogComponent.tsx
@@ -6,13 +6,16 @@
 import React from "react";
 import { ChangeLogComponentProps } from "@/interfaces/types";
 import { Button } from "@/components/ui/button";
+import ExpandableText from "./ExpandableText";
 
 const ChangeLogComponent: React.FC<ChangeLogComponentProps> = ({
   title,
   databaseUpdates,
   designAndBugFixes,
   frontEndLink,
+  frontEndTag,
   backEndLink,
+  backEndTag,
   isCurrent,
 }) => {
   // Conditional variable assignments
@@ -41,16 +44,42 @@ const ChangeLogComponent: React.FC<ChangeLogComponentProps> = ({
           aria-label={`${title} repository links`}
           className="flex flex-row justify-self-end gap-2 lg:gap-x-2.5"
         >
-          <Button variant="default" size="sm" asChild>
-            <a href={frontEndLink} target="_blank" rel="noopener noreferrer">
-              Frontend Repository
-            </a>
-          </Button>
-          <Button variant="default" size="sm" asChild>
-            <a href={backEndLink} target="_blank" rel="noopener noreferrer">
-              Backend Repository
-            </a>
-          </Button>
+          {!(frontEndTag === "latest") ? 
+            (<div className="flex flex-col">
+            <Button variant="default" size="sm" asChild>
+              <a href={frontEndLink} target="_blank" rel="noopener noreferrer">
+                Frontend Repository
+              </a>
+            </Button>
+            <p className="text-neutral-content text-sm">
+              {frontEndTag}
+            </p>
+            </div>)
+            :
+            <Button variant="default" size="sm" asChild>
+              <a href={frontEndLink} target="_blank" rel="noopener noreferrer">
+                Frontend Repository
+              </a>
+            </Button>   
+          }
+          {!(backEndTag === "latest") ? 
+            (<div className="flex flex-col">
+            <Button variant="default" size="sm" asChild>
+              <a href={backEndLink} target="_blank" rel="noopener noreferrer">
+                Backend Repository
+              </a>
+            </Button>
+            <p className="text-neutral-content text-sm">
+              {backEndTag}
+            </p>
+            </div>)
+            :
+            <Button variant="default" size="sm" asChild>
+              <a href={backEndLink} target="_blank" rel="noopener noreferrer">
+                Backend Repository
+              </a>
+            </Button>   
+          }
         </nav>
       </header>
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
@@ -65,9 +94,21 @@ const ChangeLogComponent: React.FC<ChangeLogComponentProps> = ({
             Database Updates
           </h4>
           <ul className="text-sm lg:text-base">
-            {updatesDatabaseUpdatesArray.map((update, index) => (
-              <li key={index}>• {update}</li>
-            ))}
+            {updatesDatabaseUpdatesArray.length > 5 ?
+              (<ExpandableText preview={
+                updatesDatabaseUpdatesArray.slice(0, 10).map((update, index) => (
+                  <li key={index}>• {update}</li>
+                ))
+              }>
+              {updatesDatabaseUpdatesArray.slice(10).map((update, index) => (
+                <li key={index}>• {update}</li>
+              ))}
+              </ExpandableText>)
+              :
+              updatesDatabaseUpdatesArray.map((update, index) => (
+                  <li key={index}>• {update}</li>
+              ))
+            }
           </ul>
         </section>
         <section
@@ -81,9 +122,21 @@ const ChangeLogComponent: React.FC<ChangeLogComponentProps> = ({
             Design & Bug Fixes
           </h4>
           <ul className="text-sm lg:text-base">
-            {updatesDesignAndBugFixesArray.map((update, index) => (
-              <li key={index}>• {update}</li>
-            ))}
+            {updatesDesignAndBugFixesArray.length > 5 ?
+              (<ExpandableText preview={
+                updatesDesignAndBugFixesArray.slice(0, 10).map((update, index) => (
+                  <li key={index}>• {update}</li>
+                ))
+              }>
+              {updatesDesignAndBugFixesArray.slice(10).map((update, index) => (
+                <li key={index}>• {update}</li>
+              ))}
+              </ExpandableText>)
+              :
+              updatesDesignAndBugFixesArray.map((update, index) => (
+                  <li key={index}>• {update}</li>
+              ))
+            }
           </ul>
         </section>
       </div>

--- a/next-app/src/constants.ts
+++ b/next-app/src/constants.ts
@@ -30,7 +30,7 @@ export const backendAPI = backendAPI_tmp;
 // 2. To label the changelog page with the current version when creating a new changelog
 // Currently, currentVersion is a placeholder and not used correctly. The version number is
 // not automatic or controlled by any entity. TBD
-export const currentVersion: string = "1.0.0";
+export const currentVersion: string = "1.0.1";
 export const currentVersionFormatted: string = `${
   currentVersion.split(".")[0]
 }_${currentVersion.split(".")[1]}`;

--- a/next-app/src/content/ChangeLog.ts
+++ b/next-app/src/content/ChangeLog.ts
@@ -1,0 +1,31 @@
+import { currentVersion } from "@/constants"
+import { changeLogData } from "@/interfaces/types";
+
+export const changeLogCurrent: changeLogData = {
+    version: currentVersion,
+    frontendReleaseTag: "latest",
+    backendReleaseTag: "latest",
+    databaseUpdates: [],
+    designAndBugFixes: [
+        "Fixed minor typo/formating issue on citations page.",
+        "Plot download buttons are no longer set to low opacity.",
+        "Removed lime and purple colors, replaced with teal for design consistency.",
+        "Added SVG-icon indicating a download to buttons on plot page.",
+        "Updated Change Log page, clarifying versioning and adding correct repository links."
+    ]
+
+}
+
+export const changeLogHistory: changeLogData[] = [
+    {
+        version: "1.0.0",
+        frontendReleaseTag: "1.0.0",
+        backendReleaseTag: "1.0.1",
+        databaseUpdates: [
+            "Initial release containing IGH data.",
+        ],
+        designAndBugFixes: [
+            "Initial release.",
+        ]
+    },
+];

--- a/next-app/src/interfaces/types.ts
+++ b/next-app/src/interfaces/types.ts
@@ -29,7 +29,9 @@ export type ChangeLogComponentProps = {
   databaseUpdates: string | Array<string>;
   designAndBugFixes: string | Array<string>;
   frontEndLink: string;
+  frontEndTag: string;
   backEndLink: string;
+  backEndTag: string;
   isCurrent: boolean;
 };
 
@@ -116,4 +118,12 @@ export type IAxiosConfig = {
 export type IAxiosConfigHeaders = {
   "X-api-key": string;
   "Content-Type"?: string;
+}
+
+export type changeLogData = {
+    version: string,
+    frontendReleaseTag: string,
+    backendReleaseTag: string,
+    databaseUpdates: string[],
+    designAndBugFixes: string[]
 }


### PR DESCRIPTION
https://scilifelab.atlassian.net/browse/TP-768

* Updated Change Log page to use changeLogCurrent and changeLogHistory objects in the new file ChangeLog.ts. 
* Added functionality to automatically detect and write out which version contains the latest update for database/design and bug fixes, if the currently viewed version has no updates. 
* Added a cutoff of 10 items for updates, after which the component ExpandableText gets added to hide the rest under a 'show more' button. 
* Added text explaining how versioning works to the top of page, removed some text for now that I'm not sure is relevant or not anymore. 
* Incremented currentVersion and package-lock version.